### PR TITLE
Add vcpkg export option to GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,13 +130,13 @@ jobs:
       - name: "Export built packages with 'vcpkg export'"
         if: success() && github.event.inputs.vcpkg_export == 'true' && matrix.sanitizer == ''
         run: |
-          ./vcpkg/vcpkg export docwire:${{ matrix.triplet }} --output=docwire-vcpkg-export --raw --output-dir=.
-          ${{ runner.os == 'Windows' && 'zip -r docwire-vcpkg-export.zip docwire-vcpkg-export' || 'tar -cjf docwire-vcpkg-export.tar.bz2 docwire-vcpkg-export' }}
+          ./vcpkg/vcpkg export docwire:${{ matrix.triplet }} --output=docwire-vcpkg-export-${{ matrix.triplet }}-${{ matrix.os }}-${{ github.sha }} --raw --output-dir=.
+          cmake -E tar czvf docwire-vcpkg-export-${{ matrix.triplet }}-${{ matrix.os }}-${{ github.sha }}.tar.gz docwire-vcpkg-export
       - name: "Upload 'vcpkg export' archive"
         uses: actions/upload-artifact@v4
         if: success() && github.event.inputs.vcpkg_export == 'true' && matrix.sanitizer == ''
         with:
           name: ${{ matrix.triplet }}-${{ matrix.os }}-binaries
           path: |
-            ${{ runner.os == 'Windows' && 'docwire-vcpkg-export.zip' || 'docwire-vcpkg-export.tar.bz2' }}
+            docwire-vcpkg-export-${{ matrix.triplet }}-${{ matrix.os }}-${{ github.sha }}.tar.gz
           if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '0 3 * * *'
   workflow_dispatch:
+    inputs:
+      vcpkg_export:
+        description: 'Create vcpkg export archive'
+        type: boolean
+        default: false
 run-name: ${{ github.event_name == 'pull_request' && github.event.pull_request.title || github.event_name == 'schedule' && 'Daily build' || 'Manual build' }}
 permissions:
   packages: write
@@ -121,4 +126,17 @@ jobs:
           path: |
             vcpkg/buildtrees/*/*.log
             ${{ matrix.sanitizer == 'callgrind' && 'vcpkg/buildtrees/**/callgrind.out.*' || '' }}
+          if-no-files-found: error
+      - name: "Export built packages with 'vcpkg export'"
+        if: success() && github.event.input.vcpkg_export == 'true' && matrix.sanitizer == ''
+        run: |
+          ./vcpkg/vcpkg export docwire:${{ matrix.triplet }} --output=docwire-vcpkg-export --raw --output-dir=.
+          ${{ runner.os == 'Windows' && 'zip -r docwire-vcpkg-export.zip docwire-vcpkg-export' || 'tar -cjf docwire-vcpkg-export.tar.bz2 docwire-vcpkg-export' }}
+      - name: "Upload 'vcpkg export' archive"
+        uses: actions/upload-artifact@v4
+        if: success() && github.event.input.vcpkg_export == 'true' && matrix.sanitizer == ''
+        with:
+          name: ${{ matrix.triplet }}-${{ matrix.os }}-binaries
+          path: |
+            ${{ runner.os == 'Windows' && 'docwire-vcpkg-export.zip' || 'docwire-vcpkg-export.tar.bz2' }}
           if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,13 +130,13 @@ jobs:
       - name: "Export built packages with 'vcpkg export'"
         if: success() && github.event.inputs.vcpkg_export == 'true' && matrix.sanitizer == ''
         run: |
-          ./vcpkg/vcpkg export docwire:${{ matrix.triplet }} --output=docwire-vcpkg-export-${{ matrix.triplet }}-${{ matrix.os }}-${{ github.sha }} --raw --output-dir=.
-          cmake -E tar czvf docwire-vcpkg-export-${{ matrix.triplet }}-${{ matrix.os }}-${{ github.sha }}.tar.gz docwire-vcpkg-export
+          ./vcpkg/vcpkg export docwire:${{ matrix.triplet }} --output=docwire-vcpkg --raw --output-dir=.
+          cmake -E tar czvf docwire-vcpkg-${{ matrix.triplet }}-${{ matrix.os }}-${{ github.sha }}.tar.gz docwire-vcpkg
       - name: "Upload 'vcpkg export' archive"
         uses: actions/upload-artifact@v4
         if: success() && github.event.inputs.vcpkg_export == 'true' && matrix.sanitizer == ''
         with:
           name: ${{ matrix.triplet }}-${{ matrix.os }}-binaries
           path: |
-            docwire-vcpkg-export-${{ matrix.triplet }}-${{ matrix.os }}-${{ github.sha }}.tar.gz
+            docwire-vcpkg-${{ matrix.triplet }}-${{ matrix.os }}-${{ github.sha }}.tar.gz
           if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,13 +128,13 @@ jobs:
             ${{ matrix.sanitizer == 'callgrind' && 'vcpkg/buildtrees/**/callgrind.out.*' || '' }}
           if-no-files-found: error
       - name: "Export built packages with 'vcpkg export'"
-        if: success() && github.event.input.vcpkg_export == 'true' && matrix.sanitizer == ''
+        if: success() && github.event.inputs.vcpkg_export == 'true' && matrix.sanitizer == ''
         run: |
           ./vcpkg/vcpkg export docwire:${{ matrix.triplet }} --output=docwire-vcpkg-export --raw --output-dir=.
           ${{ runner.os == 'Windows' && 'zip -r docwire-vcpkg-export.zip docwire-vcpkg-export' || 'tar -cjf docwire-vcpkg-export.tar.bz2 docwire-vcpkg-export' }}
       - name: "Upload 'vcpkg export' archive"
         uses: actions/upload-artifact@v4
-        if: success() && github.event.input.vcpkg_export == 'true' && matrix.sanitizer == ''
+        if: success() && github.event.inputs.vcpkg_export == 'true' && matrix.sanitizer == ''
         with:
           name: ${{ matrix.triplet }}-${{ matrix.os }}-binaries
           path: |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new input parameter `vcpkg_export` to the workflow, allowing users to optionally create a vcpkg export archive during the build process.
	- Added steps to export built packages and upload the generated archive when the `vcpkg_export` input is set to `true`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->