### PR TITLE
Fix conflict between ctranslate2 and nlohmann-json vcpkg ports

### DIFF
--- a/ports/ctranslate2/portfile.cmake
+++ b/ports/ctranslate2/portfile.cmake
@@ -92,4 +92,7 @@ vcpkg_cmake_configure(
 
 vcpkg_cmake_install()
 
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/nlohmann")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include/nlohmann")
+
 vcpkg_install_copyright(FILE_LIST ${SOURCE_PATH}/LICENSE)

--- a/ports/ctranslate2/vcpkg.json
+++ b/ports/ctranslate2/vcpkg.json
@@ -1,11 +1,12 @@
 {
 	"name": "ctranslate2",
 	"version": "4.3.1",
-	"port-version": 1,
+	"port-version": 2,
 	"description": "OpenNMT CTranslate2",
 	"homepage": "https://github.com/OpenNMT/CTranslate2",
 	"license": "MIT",
 	"dependencies": [
+		"nlohmann-json",
 		{
 			"name": "onednn",
 			"platform": "x64"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CTranslate2 vcpkg port configuration to properly manage package dependencies and resolve header inclusion conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->