### PR TITLE
Improve ai::embed API by enforcing non-null model runner

### DIFF
--- a/src/ai_embed.cpp
+++ b/src/ai_embed.cpp
@@ -25,7 +25,7 @@ namespace docwire
 template <>
 struct pimpl_impl<ai::embed> : pimpl_impl_base
 {
-    std::shared_ptr<ai::ai_runner> m_model_runner;
+    not_null<std::shared_ptr<ai::ai_runner>> m_model_runner;
     std::string m_prefix;
 
     pimpl_impl(not_null<std::shared_ptr<ai::ai_runner>> model_runner, std::string prefix)

--- a/src/ai_embed.cpp
+++ b/src/ai_embed.cpp
@@ -28,7 +28,7 @@ struct pimpl_impl<ai::embed> : pimpl_impl_base
     std::shared_ptr<ai::ai_runner> m_model_runner;
     std::string m_prefix;
 
-    pimpl_impl(std::shared_ptr<ai::ai_runner> model_runner, std::string prefix)
+    pimpl_impl(not_null<std::shared_ptr<ai::ai_runner>> model_runner, std::string prefix)
         : m_model_runner(std::move(model_runner)), m_prefix(std::move(prefix))
     {
     }
@@ -37,7 +37,7 @@ struct pimpl_impl<ai::embed> : pimpl_impl_base
 namespace ai
 {
 
-embed::embed(std::shared_ptr<ai_runner> model_runner, std::string prefix)
+embed::embed(not_null<std::shared_ptr<ai_runner>> model_runner, std::string prefix)
     : with_pimpl<embed>(std::move(model_runner), std::move(prefix))
 {}
 

--- a/src/ai_embed.h
+++ b/src/ai_embed.h
@@ -15,6 +15,7 @@
 #include "ai_export.h"
 #include "ai_runner.h"
 #include "chain_element.h"
+#include "not_null.h"
 #include "pimpl.h"
 
 namespace docwire::ai
@@ -29,7 +30,7 @@ class DOCWIRE_AI_EXPORT embed : public chain_element, public with_pimpl<embed>
      * @param ai_runner The model runner to use for generating embeddings.
      * @param prefix The string to prepend to the input text. Use an empty string for no prefix.
      */
-    explicit embed(std::shared_ptr<ai_runner> model_runner, std::string prefix);
+    explicit embed(not_null<std::shared_ptr<ai_runner>> model_runner, std::string prefix);
     continuation operator()(message_ptr msg, const message_callbacks& emit_message) override;
     bool is_leaf() const override { return false; }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Strengthened type safety for model runner initialization by requiring a non-null model runner when constructing the embed component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->