### PR TITLE
Fixing irregular namings of flags and features in vcpkg and CMake Flags to attain consistency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.17)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON) # for VSCode CLangd extension
 
-option(DOCWIRE_LOCAL_CT2 "Enable local AI (Translation / Text Generation / Embedding models)" OFF)
+option(DOCWIRE_CT2 "Enable default CT2 local models (Translation / Text Generation / Embedding models)" OFF)
 option(DOCWIRE_LLAMA    "Enable llama.cpp engine" OFF)
 
 # Get version from ChangeLog.md and store it in DOCWIRE_VERSION and SIMPLE_DOCWIRE_VERSION

--- a/ports/docwire/portfile.cmake
+++ b/ports/docwire/portfile.cmake
@@ -13,7 +13,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 		asan ADDRESS_SANITIZER
 		tsan THREAD_SANITIZER
 		helgrind HELGRIND_ENABLED
-		local-ai DOCWIRE_LOCAL_CT2
+		local-ai-ct2 DOCWIRE_CT2
         llama-engine DOCWIRE_LLAMA
 )
 

--- a/ports/docwire/portfile.cmake
+++ b/ports/docwire/portfile.cmake
@@ -14,7 +14,7 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
 		tsan THREAD_SANITIZER
 		helgrind HELGRIND_ENABLED
 		local-ai-ct2 DOCWIRE_CT2
-        llama-engine DOCWIRE_LLAMA
+        local-ai-llama DOCWIRE_LLAMA
 )
 
 if(DEFINED ENV{CMAKE_MESSAGE_LOG_LEVEL})

--- a/ports/docwire/vcpkg.json
+++ b/ports/docwire/vcpkg.json
@@ -39,7 +39,7 @@
 			"flan-t5-large-ct2-int8"
 			]
 	    },
-		"llama-engine":
+		"local-ai-llama":
 		{
 			"description": "Enable GGUF-based LLM inference (llama.cpp)",
 			"dependencies": [
@@ -47,11 +47,11 @@
 			"llama-cpp"
 			]
 		},
-    	"llama-granite":
+    	"local-ai-model-granite":
 		{
 			"description": "Install IBM Granite 4.0 1B Q8_0 GGUF model",
 			"dependencies": [
-			{ "name": "docwire", "features": ["llama-engine"] },
+			{ "name": "docwire", "features": ["local-ai-llama"] },
 			"granite-4-1b-q8-0"
 			]
 		}

--- a/ports/docwire/vcpkg.json
+++ b/ports/docwire/vcpkg.json
@@ -29,7 +29,7 @@
 		{
 			"description": "Enable valgrind callgrind in automatic tests"
 		},
-		"local-ai":
+		"local-ai-ct2":
 		{
 			"description": "Enable local AI runtime",
 			"dependencies": [
@@ -43,7 +43,7 @@
 		{
 			"description": "Enable GGUF-based LLM inference (llama.cpp)",
 			"dependencies": [
-			{ "name": "docwire", "features": ["local-ai"] },
+			{ "name": "docwire", "features": ["local-ai-ct2"] },
 			"llama-cpp"
 			]
 		},

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,7 +24,7 @@ include(mail.cmake)
 include(archives.cmake)
 include(ai.cmake)
 
-if(DOCWIRE_LOCAL_CT2)
+if(DOCWIRE_CT2)
     include(ai_ct2.cmake)
 endif()
 
@@ -32,7 +32,7 @@ if(DOCWIRE_LLAMA)
     include(ai_llama.cmake)
 endif()
 
-if(DOCWIRE_LOCAL_CT2 OR DOCWIRE_LLAMA)
+if(DOCWIRE_CT2 OR DOCWIRE_LLAMA)
     include(local_ai.cmake)
 endif()
 

--- a/src/ai_ct2.cmake
+++ b/src/ai_ct2.cmake
@@ -1,9 +1,9 @@
 
-message(STATUS "DOCWIRE_LOCAL_CT2 enabled: Building CT2 backend.")
+message(STATUS "DOCWIRE_CT2 enabled: Building CT2 backend.")
 
 add_library(docwire_ai_ct2 SHARED ct2_runner.cpp tokenizer.cpp)
 
-target_compile_definitions(docwire_ai_ct2 PUBLIC DOCWIRE_LOCAL_CT2)
+target_compile_definitions(docwire_ai_ct2 PUBLIC DOCWIRE_CT2)
 
 find_package(Boost REQUIRED COMPONENTS filesystem system json)
 find_package(ctranslate2 CONFIG REQUIRED)

--- a/src/cli.cmake
+++ b/src/cli.cmake
@@ -4,7 +4,7 @@ find_package(Boost REQUIRED COMPONENTS program_options)
 target_link_libraries(docwire PRIVATE docwire_core docwire_office_formats docwire_mail docwire_ocr docwire_archives
     docwire_openai docwire_ai docwire_content_type docwire_http Boost::program_options)
 
-if(DOCWIRE_LOCAL_CT2 OR DOCWIRE_LLAMA)
+if(DOCWIRE_CT2 OR DOCWIRE_LLAMA)
     target_link_libraries(docwire PRIVATE docwire_local_ai)
 endif()
 

--- a/src/docwire.cpp
+++ b/src/docwire.cpp
@@ -140,7 +140,7 @@ create_local_runner(const boost::program_options::variables_map& vm,
         #ifdef DOCWIRE_CT2
         	return std::make_shared<ai::ct2::ct2_runner>(model_path);
         #else
-        	throw std::runtime_error("CT2 model support requires the ct2-engine feature");
+        	throw std::runtime_error("CT2 model support requires the local-ai-ct2 feature");
         #endif
     }
     #ifdef DOCWIRE_CT2
@@ -148,7 +148,7 @@ create_local_runner(const boost::program_options::variables_map& vm,
         resource_path(default_model)
     );
     #else
-    	throw std::runtime_error("Default local AI model requires the ct2-engine feature");
+    	throw std::runtime_error("Default local AI model requires the local-ai-ct2 feature");
     #endif
 }
 #endif

--- a/src/docwire.cpp
+++ b/src/docwire.cpp
@@ -134,7 +134,7 @@ create_local_runner(const boost::program_options::variables_map& vm,
 	            config.n_threads = ai::thread_count{4};
 	            return std::make_shared<ai::llama::llama_runner>(config);
 	        #else
-	            throw std::runtime_error("GGUF model support requires the llama-engine feature");
+	            throw std::runtime_error("GGUF model support requires the local-ai-llama feature");
 	        #endif
         }
         #ifdef DOCWIRE_CT2

--- a/src/docwire.cpp
+++ b/src/docwire.cpp
@@ -12,7 +12,7 @@
 
 #include "model_chain_element.h"
 #include "model_inference_config.h"
-#ifdef DOCWIRE_LOCAL_CT2
+#ifdef DOCWIRE_CT2
 #include "ct2_runner.h"
 #endif
 #ifdef DOCWIRE_LLAMA
@@ -137,13 +137,13 @@ create_local_runner(const boost::program_options::variables_map& vm,
 	            throw std::runtime_error("GGUF model support requires the llama-engine feature");
 	        #endif
         }
-        #ifdef DOCWIRE_LOCAL_CT2
+        #ifdef DOCWIRE_CT2
         	return std::make_shared<ai::ct2::ct2_runner>(model_path);
         #else
         	throw std::runtime_error("CT2 model support requires the ct2-engine feature");
         #endif
     }
-    #ifdef DOCWIRE_LOCAL_CT2
+    #ifdef DOCWIRE_CT2
     return std::make_shared<ai::ct2::ct2_runner>(
         resource_path(default_model)
     );
@@ -426,7 +426,7 @@ int main(int argc, char* argv[])
 				vm.count("openai-temperature") ? vm["openai-temperature"].as<float>() : 0,
 				image_detail);
 	}
-	#ifdef DOCWIRE_LOCAL_CT2
+	#ifdef DOCWIRE_CT2
 	if (vm.count("local-ai-prompt"))
 	{
 		try
@@ -484,8 +484,8 @@ int main(int argc, char* argv[])
 	if (vm.count("local-ai-prompt") || vm.count("local-ai-embed"))
 	{
 		std::cerr << "Error: Local AI features requested, but this build does not include "
-		             "DOCWIRE_LOCAL_CT2 support.\n"
-		             "Rebuild with DOCWIRE_LOCAL_CT2 enabled to use --local-ai-prompt or "
+		             "DOCWIRE_CT2 support.\n"
+		             "Rebuild with DOCWIRE_CT2 enabled to use --local-ai-prompt or "
 		             "--local-ai-embed." << std::endl;
 		return 1;
 	}

--- a/src/docwire.h
+++ b/src/docwire.h
@@ -19,7 +19,7 @@
 #include "ai_embed.h"
 #include "ai_task.h"
 #include "model_chain_element.h"
-#ifdef DOCWIRE_LOCAL_CT2
+#ifdef DOCWIRE_CT2
 #include "ct2_runner.h"
 #endif
 #ifdef DOCWIRE_LLAMA

--- a/src/local_ai.cmake
+++ b/src/local_ai.cmake
@@ -1,4 +1,4 @@
-if(DOCWIRE_LOCAL_CT2)
+if(DOCWIRE_CT2)
     add_library(docwire_local_ai SHARED
         local_ai_summarize.cpp
         local_ai_embed.cpp
@@ -6,7 +6,7 @@ if(DOCWIRE_LOCAL_CT2)
         local_ai_task.cpp
     )
     target_link_libraries(docwire_local_ai PUBLIC docwire_ai docwire_ai_ct2)
-    target_compile_definitions(docwire_local_ai PUBLIC DOCWIRE_LOCAL_AI DOCWIRE_LOCAL_CT2)
+    target_compile_definitions(docwire_local_ai PUBLIC DOCWIRE_LOCAL_AI DOCWIRE_CT2)
     target_compile_features(docwire_local_ai PUBLIC cxx_std_20)
     target_include_directories(docwire_local_ai
         PUBLIC

--- a/tests/ai_tests.cpp
+++ b/tests/ai_tests.cpp
@@ -18,13 +18,13 @@
 #include "gtest/gtest.h"
 #include <magic_enum/magic_enum_iostream.hpp>
 #include "resource_path.h"
-#ifdef DOCWIRE_LOCAL_CT2
+#ifdef DOCWIRE_CT2
 #include "tokenizer.h"
 #endif
 
 using namespace docwire;
 
-#ifdef DOCWIRE_LOCAL_CT2
+#ifdef DOCWIRE_CT2
 TEST(tokenizer, flan_t5)
 {
     docwire::ai::ct2::tokenizer tokenizer { resource_path("flan-t5-large-ct2-int8") };


### PR DESCRIPTION
Fixing irregular namings of flags and features in vcpkg and CMake Flags to attain consistency.
Highlights:
DOCWIRE_LOCAL_CT2 renamed to DOCWIRE_LOCAL_CT2.
local-ai feature in vcpkg renamed to local-ai-ct2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Renamed the CT2 local-model build option from `DOCWIRE_LOCAL_CT2` to `DOCWIRE_CT2` and applied the new flag consistently across the build.
  * Updated package feature keys from `local-ai` → `local-ai-ct2`, and adjusted related feature wiring (including the llama feature key rename).
  * Updated CT2-related test build guards to match the new flag.

* **Bug Fixes**
  * Improved CLI and error messages so CT2 local-AI requirements now correctly reference `DOCWIRE_CT2` / `local-ai-ct2`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->