### PR TITLE
Upgrade libbfio to version 20260623

### DIFF
--- a/ports/libbfio/portfile.cmake
+++ b/ports/libbfio/portfile.cmake
@@ -1,7 +1,7 @@
 vcpkg_download_distfile(ARCHIVE
-	URLS "https://github.com/libyal/libbfio/releases/download/20240414/libbfio-alpha-20240414.tar.gz"
-	FILENAME "libbfio-alpha-20240414.tar.gz"
-	SHA512 56c7caa77f0f8b81ea54bdc5579c2fe4fe1cb1660701f0c5bf6d95817cd7dd3992f3451fe2fbd49b7aa29a59f6023af053f612c749b0519dd4b7e61d2d7059bc
+	URLS "https://github.com/libyal/libbfio/releases/download/20260623/libbfio-alpha-20260623.tar.gz"
+	FILENAME "libbfio-alpha-20260623.tar.gz"
+	SHA512 6130f8687fe258a5bed366dd48b5df346dfb815261907f4ad7e29d8f1c1c27fd0e2f10204e928ef9cc723b6c3033a4148e0c20ec048e347060d5d4de62c638f4
 )
 
 vcpkg_extract_source_archive_ex(

--- a/ports/libbfio/vcpkg.json
+++ b/ports/libbfio/vcpkg.json
@@ -1,6 +1,6 @@
 {
 	"name": "libbfio",
-	"version-date": "2024-04-14",
+	"version-date": "2026-06-23",
 	"description": "libbfio",
 	"homepage": "https://github.com/libyal/libbfio",
 	"license": "LGPL-3.0-only",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the libbfio package to a newer upstream release.
  * Refreshed the package metadata and download checksum to match the latest available archive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->