### PR TITLE
Normalize enum names to snake_case

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ std::filesystem::path("1.doc") | ... | openai::summarize(...) | openai::text_to_
 Make a text summary of voice recording (e.g. mp3 file with meeting recording) in two steps: convert voice to text and summarize text using OpenAI services (with non-default model selected):
 
 ```cpp
-std::filesystem::path("...mp3") | openai::transcribe(...) | ... | openai::summarize(..., openai::Model::gpt_4o) | out_stream;
+std::filesystem::path("...mp3") | openai::transcribe(...) | ... | openai::summarize(..., openai::model::gpt_4o) | out_stream;
 ensure(fuzzy_match::ratio(out_stream.str(), "Data processing involves converting raw data...")) > 80;
 ```
 [Full example](https://docwire.readthedocs.io/en/latest/openai_transcribe_summary_8cpp-example.html)
@@ -447,7 +447,7 @@ ensure(out_stream.str()).is_one_of({ "Data processing refers to the activities p
 Find phrases, objects and events in text or image using GPT model (with non-default model selected):
 
 ```cpp
-std::filesystem::path("scene_1.png") | ... | openai::find("tree", ..., openai::Model::gpt_4o) | out_stream;
+std::filesystem::path("scene_1.png") | ... | openai::find("tree", ..., openai::model::gpt_4o) | out_stream;
 ensure(fuzzy_match::ratio(out_stream.str(), "2\n- A tree is located on the left side...")) > 80;
 ```
 [Full example](https://docwire.readthedocs.io/en/latest/openai_find_image_8cpp-example.html)

--- a/src/analyze_data.cpp
+++ b/src/analyze_data.cpp
@@ -19,7 +19,7 @@ namespace docwire
 namespace openai
 {
 
-analyze_data::analyze_data(const std::string& api_key, Model model, float temperature, ImageDetail image_detail)
+analyze_data::analyze_data(const std::string& api_key, model model, float temperature, image_detail image_detail)
 	: chat("Your task is analyze data in every message and create a summary highlighting the most important insights, trends, key patterns, statistics, findings and other revelant information. Include conclusions that are usually made for type of data you will find in message.",
 		api_key, model, temperature, image_detail)
 {

--- a/src/analyze_data.h
+++ b/src/analyze_data.h
@@ -23,7 +23,7 @@ namespace openai
 class DOCWIRE_OPENAI_EXPORT analyze_data : public chat
 {
 public:
-	explicit analyze_data(const std::string& api_key, Model model = Model::gpt_5, float temperature = 0.0f, ImageDetail image_detail = ImageDetail::automatic);
+	explicit analyze_data(const std::string& api_key, model model = model::gpt_5, float temperature = 0.0f, image_detail image_detail = image_detail::automatic);
 };
 
 } // namespace openai

--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -58,43 +58,43 @@ chat::chat(const std::string& system_message, const std::string& api_key, model 
 namespace
 {
 
-std::string model_to_string(model model)
+std::string model_to_string(openai::model model)
 {
 	switch (model)
 	{
-		case model::gpt_5: return "gpt-5";
-		case model::gpt_5_mini: return "gpt-5-mini";
-		case model::gpt_5_nano: return "gpt-5-nano";
-		case model::gpt_5_chat_latest: return "gpt-5-chat-latest";
-		case model::gpt_41: return "gpt-4.1";
-		case model::gpt_41_mini: return "gpt-4.1-mini";
-		case model::gpt_41_nano: return "gpt-4.1-nano";
-		case model::gpt_4o: return "gpt-4o";
-		case model::gpt_4o_mini: return "gpt-4o-mini";
-		case model::o3: return "o3";
-		case model::o3_pro: return "o3-pro";
-		case model::o3_deep_research: return "o3-deep-research";
-		case model::o3_mini: return "o3-mini";
-		case model::o4_mini: return "o4-mini";
-		case model::o4_mini_deep_research: return "o4-mini-deep-research";
+		case openai::model::gpt_5: return "gpt-5";
+		case openai::model::gpt_5_mini: return "gpt-5-mini";
+		case openai::model::gpt_5_nano: return "gpt-5-nano";
+		case openai::model::gpt_5_chat_latest: return "gpt-5-chat-latest";
+		case openai::model::gpt_41: return "gpt-4.1";
+		case openai::model::gpt_41_mini: return "gpt-4.1-mini";
+		case openai::model::gpt_41_nano: return "gpt-4.1-nano";
+		case openai::model::gpt_4o: return "gpt-4o";
+		case openai::model::gpt_4o_mini: return "gpt-4o-mini";
+		case openai::model::o3: return "o3";
+		case openai::model::o3_pro: return "o3-pro";
+		case openai::model::o3_deep_research: return "o3-deep-research";
+		case openai::model::o3_mini: return "o3-mini";
+		case openai::model::o4_mini: return "o4-mini";
+		case openai::model::o4_mini_deep_research: return "o4-mini-deep-research";
 		default: throw make_error("Unexpected model value", model, errors::program_logic{});
 	}
 }
 
-std::string image_detail_to_string(image_detail image_detail)
+std::string image_detail_to_string(openai::image_detail image_detail)
 {
 	switch (image_detail)
 	{
-		case image_detail::low: return "low";
-		case image_detail::high: return "high";
-		case image_detail::automatic: return "auto";
+		case openai::image_detail::low: return "low";
+		case openai::image_detail::high: return "high";
+		case openai::image_detail::automatic: return "auto";
 		default: throw make_error("Unexpected image detail value", image_detail, errors::program_logic{});
 	}
 }
 
 enum class user_msg_type { text, image_url };
 
-std::string prepare_query(const std::string& system_msg, user_msg_type user_msg_type, const std::string& user_msg, model model, float temperature, image_detail image_detail)
+std::string prepare_query(const std::string& system_msg, openai::user_msg_type user_msg_type, const std::string& user_msg, openai::model model, float temperature, image_detail image_detail)
 {
 	log_scope(system_msg, user_msg, model, temperature, image_detail);
 	boost::json::object query
@@ -104,7 +104,7 @@ std::string prepare_query(const std::string& system_msg, user_msg_type user_msg_
 			{
 				boost::json::object {{ "role", "system" }, {"content", system_msg}},
 				boost::json::object {{ "role", "user" }, {"content",
-					user_msg_type == user_msg_type::text ?
+					user_msg_type == openai::user_msg_type::text ?
 						boost::json::value(user_msg) :
 						boost::json::array {
 							boost::json::object {
@@ -118,7 +118,7 @@ std::string prepare_query(const std::string& system_msg, user_msg_type user_msg_
 				}}
 			}
 		},
-		{ "temperature", model == model::gpt_5 || model == model::gpt_5_mini || model == model::gpt_5_nano ? 1 : temperature }
+		{ "temperature", model == openai::model::gpt_5 || model == openai::model::gpt_5_mini || model == openai::model::gpt_5_nano ? 1 : temperature }
 	};
 	return boost::json::serialize(query);
 }
@@ -164,18 +164,18 @@ continuation chat::operator()(message_ptr msg, const message_callbacks& emit_mes
 		return emit_message(std::move(msg));
 	log_entry();
 	const data_source& data = msg->get<data_source>();
-	user_msg_type user_msg_type;
+	openai::user_msg_type user_msg_type;
 	std::string data_str;
 	if (data.has_highest_confidence_mime_type_in({mime_type{"text/plain"}}))
 	{
 		log_scope();
-		user_msg_type = user_msg_type::text;
+		user_msg_type = openai::user_msg_type::text;
 		data_str = data.string();
 	}
 	else if (data.has_highest_confidence_mime_type_in({mime_type{"image/jpeg"}, mime_type{"image/png"}, mime_type{"image/gif"}, mime_type{"image/webp"}}))
 	{
 		log_scope();
-		user_msg_type = user_msg_type::image_url;
+		user_msg_type = openai::user_msg_type::image_url;
 		std::span<const std::byte> input_data = data.span();
 		std::string base64Encoded = base64::encode(input_data);
 		log_entry(base64Encoded);

--- a/src/chat.cpp
+++ b/src/chat.cpp
@@ -33,13 +33,13 @@ using namespace openai;
 template<>
 struct pimpl_impl<openai::chat> : pimpl_impl_base
 {
-	pimpl_impl(const std::string& system_message, const std::string& api_key, Model model, float temperature, ImageDetail image_detail)
+	pimpl_impl(const std::string& system_message, const std::string& api_key, model model, float temperature, image_detail image_detail)
 		: m_system_message(system_message), m_api_key(api_key), m_model(model), m_temperature(temperature), m_image_detail(image_detail) {}
 	std::string m_system_message;
 	std::string m_api_key;
-	Model m_model;
+	model m_model;
 	float m_temperature;
-	ImageDetail m_image_detail;
+	image_detail m_image_detail;
 };
 
 }
@@ -49,7 +49,7 @@ namespace docwire
 namespace openai
 {
 
-chat::chat(const std::string& system_message, const std::string& api_key, Model model, float temperature, ImageDetail image_detail)
+chat::chat(const std::string& system_message, const std::string& api_key, model model, float temperature, image_detail image_detail)
 	: with_pimpl<chat>(system_message, api_key, model, temperature, image_detail)
 {
 	log_scope(system_message, model, temperature, image_detail);
@@ -58,43 +58,43 @@ chat::chat(const std::string& system_message, const std::string& api_key, Model 
 namespace
 {
 
-std::string model_to_string(Model model)
+std::string model_to_string(model model)
 {
 	switch (model)
 	{
-		case Model::gpt_5: return "gpt-5";
-		case Model::gpt_5_mini: return "gpt-5-mini";
-		case Model::gpt_5_nano: return "gpt-5-nano";
-		case Model::gpt_5_chat_latest: return "gpt-5-chat-latest";
-		case Model::gpt_41: return "gpt-4.1";
-		case Model::gpt_41_mini: return "gpt-4.1-mini";
-		case Model::gpt_41_nano: return "gpt-4.1-nano";
-		case Model::gpt_4o: return "gpt-4o";
-		case Model::gpt_4o_mini: return "gpt-4o-mini";
-		case Model::o3: return "o3";
-		case Model::o3_pro: return "o3-pro";
-		case Model::o3_deep_research: return "o3-deep-research";
-		case Model::o3_mini: return "o3-mini";
-		case Model::o4_mini: return "o4-mini";
-		case Model::o4_mini_deep_research: return "o4-mini-deep-research";
+		case model::gpt_5: return "gpt-5";
+		case model::gpt_5_mini: return "gpt-5-mini";
+		case model::gpt_5_nano: return "gpt-5-nano";
+		case model::gpt_5_chat_latest: return "gpt-5-chat-latest";
+		case model::gpt_41: return "gpt-4.1";
+		case model::gpt_41_mini: return "gpt-4.1-mini";
+		case model::gpt_41_nano: return "gpt-4.1-nano";
+		case model::gpt_4o: return "gpt-4o";
+		case model::gpt_4o_mini: return "gpt-4o-mini";
+		case model::o3: return "o3";
+		case model::o3_pro: return "o3-pro";
+		case model::o3_deep_research: return "o3-deep-research";
+		case model::o3_mini: return "o3-mini";
+		case model::o4_mini: return "o4-mini";
+		case model::o4_mini_deep_research: return "o4-mini-deep-research";
 		default: throw make_error("Unexpected model value", model, errors::program_logic{});
 	}
 }
 
-std::string image_detail_to_string(ImageDetail image_detail)
+std::string image_detail_to_string(image_detail image_detail)
 {
 	switch (image_detail)
 	{
-		case ImageDetail::low: return "low";
-		case ImageDetail::high: return "high";
-		case ImageDetail::automatic: return "auto";
+		case image_detail::low: return "low";
+		case image_detail::high: return "high";
+		case image_detail::automatic: return "auto";
 		default: throw make_error("Unexpected image detail value", image_detail, errors::program_logic{});
 	}
 }
 
-enum class UserMsgType { text, image_url };
+enum class user_msg_type { text, image_url };
 
-std::string prepare_query(const std::string& system_msg, UserMsgType user_msg_type, const std::string& user_msg, Model model, float temperature, ImageDetail image_detail)
+std::string prepare_query(const std::string& system_msg, user_msg_type user_msg_type, const std::string& user_msg, model model, float temperature, image_detail image_detail)
 {
 	log_scope(system_msg, user_msg, model, temperature, image_detail);
 	boost::json::object query
@@ -104,7 +104,7 @@ std::string prepare_query(const std::string& system_msg, UserMsgType user_msg_ty
 			{
 				boost::json::object {{ "role", "system" }, {"content", system_msg}},
 				boost::json::object {{ "role", "user" }, {"content",
-					user_msg_type == UserMsgType::text ?
+					user_msg_type == user_msg_type::text ?
 						boost::json::value(user_msg) :
 						boost::json::array {
 							boost::json::object {
@@ -118,7 +118,7 @@ std::string prepare_query(const std::string& system_msg, UserMsgType user_msg_ty
 				}}
 			}
 		},
-		{ "temperature", model == Model::gpt_5 || model == Model::gpt_5_mini || model == Model::gpt_5_nano ? 1 : temperature }
+		{ "temperature", model == model::gpt_5 || model == model::gpt_5_mini || model == model::gpt_5_nano ? 1 : temperature }
 	};
 	return boost::json::serialize(query);
 }
@@ -164,18 +164,18 @@ continuation chat::operator()(message_ptr msg, const message_callbacks& emit_mes
 		return emit_message(std::move(msg));
 	log_entry();
 	const data_source& data = msg->get<data_source>();
-	UserMsgType user_msg_type;
+	user_msg_type user_msg_type;
 	std::string data_str;
 	if (data.has_highest_confidence_mime_type_in({mime_type{"text/plain"}}))
 	{
 		log_scope();
-		user_msg_type = UserMsgType::text;
+		user_msg_type = user_msg_type::text;
 		data_str = data.string();
 	}
 	else if (data.has_highest_confidence_mime_type_in({mime_type{"image/jpeg"}, mime_type{"image/png"}, mime_type{"image/gif"}, mime_type{"image/webp"}}))
 	{
 		log_scope();
-		user_msg_type = UserMsgType::image_url;
+		user_msg_type = user_msg_type::image_url;
 		std::span<const std::byte> input_data = data.span();
 		std::string base64Encoded = base64::encode(input_data);
 		log_entry(base64Encoded);

--- a/src/chat.h
+++ b/src/chat.h
@@ -24,7 +24,7 @@ namespace openai
 /**
  * @brief OpenAI models available for chat.
  */
-enum class Model
+enum class model
 {
 	/// GPT-5: The best model for coding and agentic tasks across domains
 	gpt_5,
@@ -58,7 +58,7 @@ enum class Model
 	o4_mini_deep_research
 };
 
-enum class ImageDetail
+enum class image_detail
 {
 	low, high, automatic
 };
@@ -66,7 +66,7 @@ enum class ImageDetail
 class DOCWIRE_OPENAI_EXPORT chat : public chain_element, public with_pimpl<chat>
 {
 public:
-	chat(const std::string& system_message, const std::string& api_key, Model model = Model::gpt_5, float temperature = 0.7, ImageDetail image_detail = ImageDetail::automatic);
+	chat(const std::string& system_message, const std::string& api_key, model model = model::gpt_5, float temperature = 0.7, image_detail image_detail = image_detail::automatic);
 
 	/**
 	* @brief Executes transform operation for given node data.

--- a/src/classify.cpp
+++ b/src/classify.cpp
@@ -20,7 +20,7 @@ namespace docwire
 namespace openai
 {
 
-classify::classify(const std::set<std::string>& categories, const std::string& api_key, Model model, float temperature, ImageDetail image_detail)
+classify::classify(const std::set<std::string>& categories, const std::string& api_key, model model, float temperature, image_detail image_detail)
 	: chat("Your task is to classify every message to one of the following categories: " + boost::algorithm::join(categories, ", ")
 			+ ". Answer with the category name only, exactly as it was written.",
 			api_key, model, temperature, image_detail)

--- a/src/classify.h
+++ b/src/classify.h
@@ -24,7 +24,7 @@ namespace openai
 class DOCWIRE_OPENAI_EXPORT classify : public chat
 {
 public:
-	classify(const std::set<std::string>& categories, const std::string& api_key, Model model = Model::gpt_5, float temperature = 0, ImageDetail image_detail = ImageDetail::automatic);
+	classify(const std::set<std::string>& categories, const std::string& api_key, model model = model::gpt_5, float temperature = 0, image_detail image_detail = image_detail::automatic);
 };
 
 } // namespace openai

--- a/src/common_xml_document_parser.cpp
+++ b/src/common_xml_document_parser.cpp
@@ -62,7 +62,7 @@ struct pimpl_impl<common_xml_document_parser<safety_level>> : with_pimpl_owner<c
   template<typename T>
   command_handler add_command_handler(T member_function)
   {
-    return [this, member_function](xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+    return [this, member_function](xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
                                  zip_reader* zipfile, std::string& text,
                                  bool& children_processed, std::string& level_suffix, bool first_on_level)
     {
@@ -123,7 +123,7 @@ struct pimpl_impl<common_xml_document_parser<safety_level>> : with_pimpl_owner<c
 		m_context_stack.top().is_underline = false;
 	}
 
-  void onpPr(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+  void onpPr(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
            zip_reader* zipfile, std::string& text,
            bool& children_processed, std::string& level_suffix, bool first_on_level)
   {
@@ -146,7 +146,7 @@ struct pimpl_impl<common_xml_document_parser<safety_level>> : with_pimpl_owner<c
     reset_format();
   }
 
-	void onR(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+	void onR(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
 	           zip_reader* zipfile, std::string& text,
 	           bool& children_processed, std::string& level_suffix, bool first_on_level)
 	{
@@ -169,7 +169,7 @@ struct pimpl_impl<common_xml_document_parser<safety_level>> : with_pimpl_owner<c
 		reset_format();
 	}
 
-  void onrPr(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+  void onrPr(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
                       zip_reader* zipfile, std::string& text,
                       bool& children_processed, std::string& level_suffix, bool first_on_level)
   {
@@ -191,7 +191,7 @@ struct pimpl_impl<common_xml_document_parser<safety_level>> : with_pimpl_owner<c
     children_processed = true;
   }
 
-  void onODFOOXMLPara(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+  void onODFOOXMLPara(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
                       zip_reader* zipfile, std::string& text,
                       bool& children_processed, std::string& level_suffix, bool first_on_level)
   {
@@ -203,7 +203,7 @@ struct pimpl_impl<common_xml_document_parser<safety_level>> : with_pimpl_owner<c
     emit_message(document::close_paragraph{});
   }
 
-  void onODFOOXMLText(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+  void onODFOOXMLText(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
                         const zip_reader* zipfile, std::string& text,
                         bool& children_processed, std::string& level_suffix, bool first_on_level)
   {
@@ -219,7 +219,7 @@ struct pimpl_impl<common_xml_document_parser<safety_level>> : with_pimpl_owner<c
     }
   }
 
-  void onODFOOXMLTable(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+  void onODFOOXMLTable(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
                  zip_reader* zipfile, std::string& text,
                  bool& children_processed, std::string& level_suffix, bool first_on_level)
   {
@@ -231,7 +231,7 @@ struct pimpl_impl<common_xml_document_parser<safety_level>> : with_pimpl_owner<c
     emit_message(document::close_table{});
   }
 
-  void onODFOOXMLTableRow(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+  void onODFOOXMLTableRow(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
                        zip_reader* zipfile, std::string& text,
                        bool& children_processed, std::string& level_suffix, bool first_on_level)
   {
@@ -243,7 +243,7 @@ struct pimpl_impl<common_xml_document_parser<safety_level>> : with_pimpl_owner<c
     emit_message(document::close_table_row{});
   }
 
-  void onODFOOXMLTableCell(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+  void onODFOOXMLTableCell(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
                        zip_reader* zipfile, std::string& text,
                        bool& children_processed, std::string& level_suffix, bool first_on_level)
   {
@@ -255,7 +255,7 @@ struct pimpl_impl<common_xml_document_parser<safety_level>> : with_pimpl_owner<c
     emit_message(document::close_table_cell{});
   }
 
-  void onODFOOXMLTextTag(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+  void onODFOOXMLTextTag(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
                       zip_reader* zipfile, std::string& text,
                       bool& children_processed, std::string& level_suffix, bool first_on_level)
   {
@@ -264,7 +264,7 @@ struct pimpl_impl<common_xml_document_parser<safety_level>> : with_pimpl_owner<c
     children_processed = true;
   }
 
-  void onODFOOXMLBold(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+  void onODFOOXMLBold(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
                       const zip_reader* zipfile, std::string& text,
                       bool& children_processed, std::string& level_suffix, bool first_on_level)
   {
@@ -272,7 +272,7 @@ struct pimpl_impl<common_xml_document_parser<safety_level>> : with_pimpl_owner<c
 	m_context_stack.top().is_bold = attribute_value(xml_node, "val").value_or("") != "false";
   }
 
-  void onODFOOXMLItalic(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+  void onODFOOXMLItalic(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
                       const zip_reader* zipfile, std::string& text,
                       bool& children_processed, std::string& level_suffix, bool first_on_level)
   {
@@ -280,7 +280,7 @@ struct pimpl_impl<common_xml_document_parser<safety_level>> : with_pimpl_owner<c
 	m_context_stack.top().is_italic = attribute_value(xml_node, "val").value_or("") != "false";
   }
 
-  void onODFOOXMLUnderline(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+  void onODFOOXMLUnderline(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
                       const zip_reader* zipfile, std::string& text,
                       bool& children_processed, std::string& level_suffix, bool first_on_level)
   {
@@ -288,7 +288,7 @@ struct pimpl_impl<common_xml_document_parser<safety_level>> : with_pimpl_owner<c
 	m_context_stack.top().is_underline = attribute_value(xml_node, "val").value_or("") != "none";
   }
 
-	void onUnregisteredCommand(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+	void onUnregisteredCommand(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
 								const zip_reader* zipfile, std::string& text,
 								bool& children_processed, std::string& level_suffix, bool first_on_level)
 	{
@@ -303,7 +303,7 @@ struct pimpl_impl<common_xml_document_parser<safety_level>> : with_pimpl_owner<c
 		}
 	}
 
-	void executeCommand(const std::string& command, xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+	void executeCommand(const std::string& command, xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
 						zip_reader* zipfile, std::string& text,
 						bool& children_processed, std::string& level_suffix, bool first_on_level)
 	{
@@ -316,7 +316,7 @@ struct pimpl_impl<common_xml_document_parser<safety_level>> : with_pimpl_owner<c
 			onUnregisteredCommand(xml_node, mode, zipfile, text, children_processed, level_suffix, first_on_level);
 	}
 
-	void onODFText(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+	void onODFText(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
 								   const zip_reader* zipfile, std::string& text,
 								   bool& children_processed, std::string& level_suffix, bool first_on_level)
 		{
@@ -324,7 +324,7 @@ struct pimpl_impl<common_xml_document_parser<safety_level>> : with_pimpl_owner<c
 			text += xml_node.content();
 		}
 
-	void onODFOOXMLTab(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+	void onODFOOXMLTab(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
 								  const zip_reader* zipfile, std::string& text,
 								  bool& children_processed, std::string& level_suffix, bool first_on_level)
 		{
@@ -333,7 +333,7 @@ struct pimpl_impl<common_xml_document_parser<safety_level>> : with_pimpl_owner<c
 			emit_message(document::text{.text = "\t"});
 		}
 
-	void onODFOOXMLSpace(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+	void onODFOOXMLSpace(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
 								  const zip_reader* zipfile, std::string& text,
 								  bool& children_processed, std::string& level_suffix, bool first_on_level)
 		{
@@ -346,7 +346,7 @@ struct pimpl_impl<common_xml_document_parser<safety_level>> : with_pimpl_owner<c
 			emit_message(document::text{.text = std::string(count, ' ')});
 		}
 
-	void onODFUrl(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+	void onODFUrl(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
 								  zip_reader* zipfile, std::string& text,
 								  bool& children_processed, std::string& level_suffix, bool first_on_level)
 		{
@@ -359,7 +359,7 @@ struct pimpl_impl<common_xml_document_parser<safety_level>> : with_pimpl_owner<c
 			emit_message(document::close_link{});
 		}
 
-	void onODFOOXMLListStyle(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+	void onODFOOXMLListStyle(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
 										const zip_reader* zipfile, std::string& text,
 										bool& children_processed, std::string& level_suffix, bool first_on_level)
 		{
@@ -385,7 +385,7 @@ struct pimpl_impl<common_xml_document_parser<safety_level>> : with_pimpl_owner<c
 			}
 		}
 
-	void onODFOOXMLList(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+	void onODFOOXMLList(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
 								   zip_reader* zipfile, std::string& text,
 								   bool& children_processed, std::string& level_suffix, bool first_on_level)
 		{
@@ -393,7 +393,7 @@ struct pimpl_impl<common_xml_document_parser<safety_level>> : with_pimpl_owner<c
 			std::vector<std::string> list_vector;
 			owner().getListDepth()++;
 			std::string header;
-			typename common_xml_document_parser<safety_level>::ODFOOXMLListStyle list_style = common_xml_document_parser<safety_level>::bullet;
+			typename common_xml_document_parser<safety_level>::odfooxml_list_style list_style = common_xml_document_parser<safety_level>::bullet;
 			std::string style_name { attribute_value(xml_node, "style-name").value_or("") };
 			if (owner().getListDepth() <= 10 && !style_name.empty() && owner().getListStyles().find(style_name) != owner().getListStyles().end())
 				list_style = owner().getListStyles()[style_name].at(owner().getListDepth() - 1);
@@ -434,7 +434,7 @@ struct pimpl_impl<common_xml_document_parser<safety_level>> : with_pimpl_owner<c
 			children_processed = true;
 		}
 
-	void onODFAnnotation(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+	void onODFAnnotation(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
 									zip_reader* zipfile, std::string& text,
 									bool& children_processed, std::string& level_suffix, bool first_on_level)
 		{
@@ -462,7 +462,7 @@ struct pimpl_impl<common_xml_document_parser<safety_level>> : with_pimpl_owner<c
 			children_processed = true;
 		}
 
-	void onODFLineBreak(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+	void onODFLineBreak(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
 								   const zip_reader* zipfile, std::string& text,
 								   bool& children_processed, std::string& level_suffix, bool first_on_level)
 		{
@@ -471,7 +471,7 @@ struct pimpl_impl<common_xml_document_parser<safety_level>> : with_pimpl_owner<c
 			emit_message(document::break_line{});
 		}
 
-	void onODFHeading(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+	void onODFHeading(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
 								 zip_reader* zipfile, std::string& text,
 								 bool& children_processed, std::string& level_suffix, bool first_on_level)
 		{
@@ -480,7 +480,7 @@ struct pimpl_impl<common_xml_document_parser<safety_level>> : with_pimpl_owner<c
 			children_processed = true;
 		}
 
-	void onODFObject(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+	void onODFObject(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
 								zip_reader* zipfile, std::string& text,
 								bool& children_processed, std::string& level_suffix, bool first_on_level)
 		{
@@ -505,7 +505,7 @@ struct pimpl_impl<common_xml_document_parser<safety_level>> : with_pimpl_owner<c
 			text += object_text;
 		}
 
-	void onOOXMLFldData(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+	void onOOXMLFldData(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
 								zip_reader* zipfile, std::string& text,
 								bool& children_processed, std::string& level_suffix, bool first_on_level)
 	{
@@ -528,7 +528,7 @@ void common_xml_document_parser<safety_level>::registerODFOOXMLCommandHandler(co
 }
 
 template <safety_policy safety_level>
-std::string common_xml_document_parser<safety_level>::parseXmlData(xml::children_view<safety_level> xml_nodes, XmlParseMode mode, zip_reader* zipfile)
+std::string common_xml_document_parser<safety_level>::parseXmlData(xml::children_view<safety_level> xml_nodes, xml_parse_mode mode, zip_reader* zipfile)
 {
 	log_scope();
 	std::string text;
@@ -563,7 +563,7 @@ std::string common_xml_document_parser<safety_level>::parseXmlData(xml::children
 
 template <safety_policy safety_level>
 std::string common_xml_document_parser<safety_level>::parseXmlChildren(
-  xml::node_ref<safety_level>& xml_node, XmlParseMode mode, zip_reader* zipfile)
+  xml::node_ref<safety_level>& xml_node, xml_parse_mode mode, zip_reader* zipfile)
 {
 	log_scope();
 	std::string text;
@@ -572,7 +572,7 @@ std::string common_xml_document_parser<safety_level>::parseXmlChildren(
 }
 
 template <safety_policy safety_level>
-void common_xml_document_parser<safety_level>::extractText(std::string_view xml_contents, XmlParseMode mode, zip_reader* zipfile,
+void common_xml_document_parser<safety_level>::extractText(std::string_view xml_contents, xml_parse_mode mode, zip_reader* zipfile,
 	std::string& text)
 {
 	log_scope();

--- a/src/common_xml_document_parser.h
+++ b/src/common_xml_document_parser.h
@@ -25,7 +25,7 @@ namespace docwire
 	class zip_reader;
 	class Metadata;
 
-enum XmlParseMode { PARSE_XML, FIX_XML, STRIP_XML };
+enum xml_parse_mode { PARSE_XML, FIX_XML, STRIP_XML };
 
 /**
  * @brief Base class for XML-based document parsers (ODF, OOXML, etc.).
@@ -47,7 +47,7 @@ class common_xml_document_parser: public chain_element, public with_pimpl<common
 	//public interface for derived classes (and its components)
 	public:
 		/// Enum for list styles (e.g., numbered or bulleted).
-		enum ODFOOXMLListStyle
+		enum odfooxml_list_style
 		{
 			number,
 			bullet
@@ -83,7 +83,7 @@ class common_xml_document_parser: public chain_element, public with_pimpl<common
 		};
 
 		/// Type alias for a vector of list styles.
-		typedef std::vector<ODFOOXMLListStyle> ListStyleVector;
+		typedef std::vector<odfooxml_list_style> ListStyleVector;
 		/// Type alias for a map of list style names to their definitions.
 		using ListStyleMap = std::map<std::string, common_xml_document_parser<safety_level>::ListStyleVector>;
 		/// Type alias for a map of comment IDs to Comment objects.
@@ -96,7 +96,7 @@ class common_xml_document_parser: public chain_element, public with_pimpl<common
 		/**
 		 * @brief Defines the function signature for an XML tag command handler.
 		 */
-		typedef std::function<void(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+		typedef std::function<void(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
                                  zip_reader* zipfile, std::string& text,
                                  bool& children_processed, std::string& level_suffix, bool first_on_level)> CommandHandler;
 
@@ -120,7 +120,7 @@ class common_xml_document_parser: public chain_element, public with_pimpl<common
 		 * @param zipfile Pointer to the zip_reader if the XML is part of a zipped archive (e.g., DOCX, ODT).
 		 * @return The extracted text content.
 		 */
-		std::string parseXmlData(xml::children_view<safety_level> xml_nodes, XmlParseMode mode, zip_reader* zipfile);
+		std::string parseXmlData(xml::children_view<safety_level> xml_nodes, xml_parse_mode mode, zip_reader* zipfile);
 
 		/**
 		 * @brief Parses the children of a given XML node.
@@ -130,7 +130,7 @@ class common_xml_document_parser: public chain_element, public with_pimpl<common
 		 * @param zipfile Pointer to the zip_reader if applicable.
 		 * @return The extracted text content from the children.
 		 */
-		std::string parseXmlChildren(xml::node_ref<safety_level>& xml_node, XmlParseMode mode, zip_reader* zipfile);
+		std::string parseXmlChildren(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode, zip_reader* zipfile);
 
 		/**
 		 * @brief Extracts text from raw XML content.
@@ -142,7 +142,7 @@ class common_xml_document_parser: public chain_element, public with_pimpl<common
 		 * @param zipfile Pointer to the zip_reader if applicable.
 		 * @param text Output parameter where the extracted text will be appended.
 		 */
-		void extractText(std::string_view xml_contents, XmlParseMode mode, zip_reader* zipfile, std::string& text);
+		void extractText(std::string_view xml_contents, xml_parse_mode mode, zip_reader* zipfile, std::string& text);
 
 		/**
 		 * @brief Parses ODF metadata from XML content.

--- a/src/detect_sentiment.cpp
+++ b/src/detect_sentiment.cpp
@@ -19,7 +19,7 @@ namespace docwire
 namespace openai
 {
 
-detect_sentiment::detect_sentiment(const std::string& api_key, Model model, float temperature, ImageDetail image_detail)
+detect_sentiment::detect_sentiment(const std::string& api_key, model model, float temperature, image_detail image_detail)
 	: chat("Your task is to detect sentiment for every message",
 			api_key, model, temperature, image_detail)
 {

--- a/src/detect_sentiment.h
+++ b/src/detect_sentiment.h
@@ -22,7 +22,7 @@ namespace openai
 class DOCWIRE_OPENAI_EXPORT detect_sentiment : public chat
 {
 public:
-	detect_sentiment(const std::string& api_key, Model model = Model::gpt_5, float temperature = 0, ImageDetail image_detail = ImageDetail::automatic);
+	detect_sentiment(const std::string& api_key, model model = model::gpt_5, float temperature = 0, image_detail image_detail = image_detail::automatic);
 };
 
 } // namespace openai

--- a/src/doc_parser.cpp
+++ b/src/doc_parser.cpp
@@ -64,7 +64,7 @@ struct pimpl_impl<doc_parser> : pimpl_impl_base
     void parse(const data_source& data, const message_callbacks& emit_message);
 };
 
-enum class TableState
+enum class table_state
 {
 	in_table,
 	in_row,
@@ -79,7 +79,7 @@ struct current_header_footer
 };
 
 // constants are from MS Word Binary File Format Specification
-enum FieldType
+enum field_type
 {
 	FLT_NONE = 0,
 	FLT_FILLIN = 0x27,
@@ -87,7 +87,7 @@ enum FieldType
 	FLT_HYPERLINK = 0x58
 };
 
-enum FieldPart
+enum field_part
 {
 	FIELD_PART_NONE,
 	FIELD_PART_PARAMS,
@@ -96,12 +96,12 @@ enum FieldPart
 
 struct current_state
 {
-	std::stack<TableState> table_state;
+	std::stack<docwire::table_state> table_state;
 	current_header_footer header_footer;
 	std::list<std::string> obj_texts;
 	std::list<std::string>::iterator obj_texts_iter;
-	FieldType field_type;
-	FieldPart field_part;
+	docwire::field_type field_type;
+	docwire::field_part field_part;
 	UString field_params;
 	UString field_value;
 	current_state() : field_type(FLT_NONE), field_part(FIELD_PART_NONE) {};
@@ -327,15 +327,15 @@ class text_handler : public wvWare::TextHandler
 			log_scope();
 			if (!m_curr_state->table_state.empty())
 			{
-				if (m_curr_state->table_state.top() == TableState::in_table)
+				if (m_curr_state->table_state.top() == table_state::in_table)
 				{
 					m_emit_message(document::close_table{});
 					m_curr_state->table_state.pop();
 				}
-				else if (m_curr_state->table_state.top() == TableState::in_row)
+				else if (m_curr_state->table_state.top() == table_state::in_row)
 				{
 					m_emit_message(document::table_cell{});
-					m_curr_state->table_state.push(TableState::in_cell);
+					m_curr_state->table_state.push(table_state::in_cell);
 				}
 			}
 			m_emit_message(document::paragraph{});
@@ -413,7 +413,7 @@ class text_handler : public wvWare::TextHandler
 			SharedPtr<const Word97::CHP> chp)
 		{
 			log_scope();
-			m_curr_state->field_type = (FieldType)fld->flt;
+			m_curr_state->field_type = (field_type)fld->flt;
 			m_curr_state->field_part = FIELD_PART_PARAMS;
 			switch (fld->flt)
 			{
@@ -519,26 +519,26 @@ class table_handler : public wvWare::TableHandler
 		void tableRowStart(SharedPtr<const Word97::TAP> tap)
 		{
 			log_scope();
-			if (m_current_state.table_state.empty() || m_current_state.table_state.top() == TableState::in_cell)
+			if (m_current_state.table_state.empty() || m_current_state.table_state.top() == table_state::in_cell)
 			{
 				m_emit_message(document::table{});
-				m_current_state.table_state.push(TableState::in_table);
+				m_current_state.table_state.push(table_state::in_table);
 			}
-			throw_if (m_current_state.table_state.top() != TableState::in_table, errors::uninterpretable_data{});
+			throw_if (m_current_state.table_state.top() != table_state::in_table, errors::uninterpretable_data{});
 			m_emit_message(document::table_row{});
-			m_current_state.table_state.push(TableState::in_row);
+			m_current_state.table_state.push(table_state::in_row);
 		}
 
 		void tableRowEnd()
 		{
 			log_scope();
 			throw_if (m_current_state.table_state.empty(), errors::uninterpretable_data{});
-			if (m_current_state.table_state.top() == TableState::in_cell)
+			if (m_current_state.table_state.top() == table_state::in_cell)
 			{
 				m_emit_message(document::close_table_cell{});
 				m_current_state.table_state.pop();
 			}
-			throw_if (m_current_state.table_state.empty() || m_current_state.table_state.top() != TableState::in_row, errors::uninterpretable_data{});
+			throw_if (m_current_state.table_state.empty() || m_current_state.table_state.top() != table_state::in_row, errors::uninterpretable_data{});
 			m_emit_message(document::close_table_row{});
 			m_current_state.table_state.pop();
 		}
@@ -546,20 +546,20 @@ class table_handler : public wvWare::TableHandler
 		void tableCellStart()
 		{
 			log_scope();
-			throw_if (m_current_state.table_state.empty() || m_current_state.table_state.top() != TableState::in_row, errors::uninterpretable_data{});
+			throw_if (m_current_state.table_state.empty() || m_current_state.table_state.top() != table_state::in_row, errors::uninterpretable_data{});
 			m_emit_message(document::table_cell{});
-			m_current_state.table_state.push(TableState::in_cell);
+			m_current_state.table_state.push(table_state::in_cell);
 		}
 
 		void tableCellEnd()
 		{
 			log_scope();
-			if (!m_current_state.table_state.empty() && m_current_state.table_state.top() == TableState::in_table)
+			if (!m_current_state.table_state.empty() && m_current_state.table_state.top() == table_state::in_table)
 			{
 				m_emit_message(document::close_table{});
 				m_current_state.table_state.pop();
 			}
-			throw_if (m_current_state.table_state.empty() || m_current_state.table_state.top() != TableState::in_cell, errors::uninterpretable_data{});
+			throw_if (m_current_state.table_state.empty() || m_current_state.table_state.top() != table_state::in_cell, errors::uninterpretable_data{});
 			m_emit_message(document::close_table_cell{});
 			m_current_state.table_state.pop();
 		}

--- a/src/docwire.cpp
+++ b/src/docwire.cpp
@@ -102,8 +102,8 @@ namespace docwire::openai
 using magic_enum::istream_operators::operator>>;
 using magic_enum::ostream_operators::operator<<;
 
-enum class OutputType { plain_text, html, csv, metadata };
-enum class EmbedPrefixType { none, query, passage };
+enum class output_type { plain_text, html, csv, metadata };
+enum class embed_prefix_type { none, query, passage };
 template<typename T>
 std::string enum_names_str()
 {
@@ -167,10 +167,10 @@ int main(int argc, char* argv[])
 		("help", "display help message")
 		("version", "display DocWire version")
 		("input-file", po::value<std::string>()->required(), "path to file to process")
-		("output_type", po::value<OutputType>()->default_value(OutputType::plain_text), enum_names_str<OutputType>().c_str())
+		("output_type", po::value<output_type>()->default_value(output_type::plain_text), enum_names_str<output_type>().c_str())
 		("http-post", po::value<std::string>(), "url to process data via http post")
 		("local-ai-prompt", po::value<std::string>(), "prompt to process text via local AI model")
-		("local-ai-embed", po::value<EmbedPrefixType>()->implicit_value(EmbedPrefixType::none), "generate embedding of text via local AI model. Optional argument selects the prefix type: (e.g. \"passage: \" or \"query: \" or \"none: \").")
+		("local-ai-embed", po::value<embed_prefix_type>()->implicit_value(embed_prefix_type::none), "generate embedding of text via local AI model. Optional argument selects the prefix type: (e.g. \"passage: \" or \"query: \" or \"none: \").")
 		("local-ai-model", po::value<std::string>(), "path to local AI model data (build-in default model is used if not specified)")
 		("openai-chat", po::value<std::string>(), "prompt to process text and images via OpenAI")
 		("openai-extract-entities", "extract entities from text and images via OpenAI")
@@ -185,14 +185,14 @@ int main(int argc, char* argv[])
 		("openai-embed", "generate embedding of text via OpenAI")
 		("openai-transcribe", "convert speech to text (transcribe) via OpenAI")
 		("openai-key", po::value<std::string>()->default_value(""), "OpenAI API key")
-		("openai-model", po::value<openai::Model>()->default_value(openai::Model::gpt_5), enum_names_str<openai::Model>().c_str())
-		("openai-tts-model", po::value<openai::text_to_speech::Model>()->default_value(openai::text_to_speech::Model::gpt_4o_mini_tts), enum_names_str<openai::text_to_speech::Model>().c_str())
+		("openai-model", po::value<openai::model>()->default_value(openai::model::gpt_5), enum_names_str<openai::model>().c_str())
+		("openai-tts-model", po::value<openai::text_to_speech::model>()->default_value(openai::text_to_speech::model::gpt_4o_mini_tts), enum_names_str<openai::text_to_speech::model>().c_str())
 		("openai-embed-model", po::value<openai::embed::model>()->default_value(openai::embed::model::text_embedding_3_small), enum_names_str<openai::embed::model>().c_str())
-		("openai-transcribe-model", po::value<openai::transcribe::Model>()->default_value(openai::transcribe::Model::gpt_4o_transcribe), enum_names_str<openai::transcribe::Model>().c_str())
-		("openai-voice", po::value<openai::text_to_speech::Voice>()->default_value(openai::text_to_speech::Voice::alloy), enum_names_str<openai::text_to_speech::Voice>().c_str())
+		("openai-transcribe-model", po::value<openai::transcribe::model>()->default_value(openai::transcribe::model::gpt_4o_transcribe), enum_names_str<openai::transcribe::model>().c_str())
+		("openai-voice", po::value<openai::text_to_speech::voice>()->default_value(openai::text_to_speech::voice::alloy), enum_names_str<openai::text_to_speech::voice>().c_str())
 		("openai-temperature", po::value<float>(), "force specified temperature for OpenAI prompts")
-		("openai-image-detail", po::value<openai::ImageDetail>()->default_value(openai::ImageDetail::automatic), enum_names_str<openai::ImageDetail>().c_str())
-		("language", po::value<std::vector<Language>>()->default_value({Language::eng}, "eng"), "Set the document language(s) for OCR as ISO 639-3 identifiers like: spa, fra, deu, rus, chi_sim, chi_tra etc. More than 100 languages are supported. Multiple languages can be enabled.")
+		("openai-image-detail", po::value<openai::image_detail>()->default_value(openai::image_detail::automatic), enum_names_str<openai::image_detail>().c_str())
+		("language", po::value<std::vector<language>>()->default_value({language::eng}, "eng"), "Set the document language(s) for OCR as ISO 639-3 identifiers like: spa, fra, deu, rus, chi_sim, chi_tra etc. More than 100 languages are supported. Multiple languages can be enabled.")
 		("ocr-confidence-threshold", po::value<float>()->notifier([](float val) {
 			if (val < 0.0f || val > 100.0f) {
 				throw po::validation_error(po::validation_error::invalid_option_value,
@@ -278,7 +278,7 @@ int main(int argc, char* argv[])
 	if (vm.count("openai-transcribe"))
 	{
 		std::string api_key = vm["openai-key"].as<std::string>();
-		openai::transcribe::Model model = vm["openai-transcribe-model"].as<openai::transcribe::Model>();
+		openai::transcribe::model model = vm["openai-transcribe-model"].as<openai::transcribe::model>();
 		chain |= openai::transcribe(api_key, model) | plain_text_exporter();
 	}
 	else if (local_processing)
@@ -290,7 +290,7 @@ int main(int argc, char* argv[])
 		}
 		chain |=
 			archives_parser{} |
-			office_formats_parser{} | mail_parser{} | ocr_parser{vm["language"].as<std::vector<Language>>(), threshold_arg};
+			office_formats_parser{} | mail_parser{} | ocr_parser{vm["language"].as<std::vector<language>>(), threshold_arg};
 		if (vm.count("max_nodes_number"))
 		{
 			chain |= standard_filter::filterByMaxNodeNumber(vm["max_nodes_number"].as<unsigned int>());
@@ -312,18 +312,18 @@ int main(int argc, char* argv[])
 			chain |= standard_filter::filterByAttachmentType({file_extension{vm["attachment_extension"].as<std::string>()}});
 		}
 
-		switch (vm["output_type"].as<OutputType>())
+		switch (vm["output_type"].as<output_type>())
 		{
-			case OutputType::plain_text:
+			case output_type::plain_text:
 				chain |= plain_text_exporter();
 				break;
-			case OutputType::html:
+			case output_type::html:
 				chain |= html_exporter();
 				break;
-			case OutputType::csv:
+			case output_type::csv:
 				chain |= csv_exporter();
 				break;
-			case OutputType::metadata:
+			case output_type::metadata:
 				chain |= metadata_exporter();
 				break;
 		}
@@ -338,8 +338,8 @@ int main(int argc, char* argv[])
 	{
 		std::string prompt = vm["openai-chat"].as<std::string>();
 		std::string api_key = vm["openai-key"].as<std::string>();
-		openai::Model model = vm["openai-model"].as<openai::Model>();
-		openai::ImageDetail image_detail = vm["openai-image-detail"].as<openai::ImageDetail>();
+		openai::model model = vm["openai-model"].as<openai::model>();
+		openai::image_detail image_detail = vm["openai-image-detail"].as<openai::image_detail>();
 		chain |=
 			openai::chat(prompt, api_key, model,
 				vm.count("openai-temperature") ? vm["openai-temperature"].as<float>() : 0,
@@ -349,8 +349,8 @@ int main(int argc, char* argv[])
 	if (vm.count("openai-extract-entities"))
 	{
 		std::string api_key = vm["openai-key"].as<std::string>();
-		openai::Model model = vm["openai-model"].as<openai::Model>();
-		openai::ImageDetail image_detail = vm["openai-image-detail"].as<openai::ImageDetail>();
+		openai::model model = vm["openai-model"].as<openai::model>();
+		openai::image_detail image_detail = vm["openai-image-detail"].as<openai::image_detail>();
 		chain |=
 			openai::extract_entities(api_key, model,
 				vm.count("openai-temperature") ? vm["openai-temperature"].as<float>() : 0,
@@ -361,8 +361,8 @@ int main(int argc, char* argv[])
 	{
 		unsigned int max_keywords = vm["openai-extract-keywords"].as<unsigned int>();
 		std::string api_key = vm["openai-key"].as<std::string>();
-		openai::Model model = vm["openai-model"].as<openai::Model>();
-		openai::ImageDetail image_detail = vm["openai-image-detail"].as<openai::ImageDetail>();
+		openai::model model = vm["openai-model"].as<openai::model>();
+		openai::image_detail image_detail = vm["openai-image-detail"].as<openai::image_detail>();
 		chain |=
 			openai::extract_keywords(max_keywords, api_key, model,
 				vm.count("openai-temperature") ? vm["openai-temperature"].as<float>() : 0,
@@ -372,8 +372,8 @@ int main(int argc, char* argv[])
 	if (vm.count("openai-summarize"))
 	{
 		std::string api_key = vm["openai-key"].as<std::string>();
-		openai::Model model = vm["openai-model"].as<openai::Model>();
-		openai::ImageDetail image_detail = vm["openai-image-detail"].as<openai::ImageDetail>();
+		openai::model model = vm["openai-model"].as<openai::model>();
+		openai::image_detail image_detail = vm["openai-image-detail"].as<openai::image_detail>();
 		chain |=
 			openai::summarize(api_key, model,
 				vm.count("openai-temperature") ? vm["openai-temperature"].as<float>() : 0,
@@ -383,8 +383,8 @@ int main(int argc, char* argv[])
 	if (vm.count("openai-detect-sentiment"))
 	{
 		std::string api_key = vm["openai-key"].as<std::string>();
-		openai::Model model = vm["openai-model"].as<openai::Model>();
-		openai::ImageDetail image_detail = vm["openai-image-detail"].as<openai::ImageDetail>();
+		openai::model model = vm["openai-model"].as<openai::model>();
+		openai::image_detail image_detail = vm["openai-image-detail"].as<openai::image_detail>();
 		chain |=
 			openai::detect_sentiment(api_key, model,
 				vm.count("openai-temperature") ? vm["openai-temperature"].as<float>() : 0,
@@ -394,8 +394,8 @@ int main(int argc, char* argv[])
 	if (vm.count("openai-analyze-data"))
 	{
 		std::string api_key = vm["openai-key"].as<std::string>();
-		openai::Model model = vm["openai-model"].as<openai::Model>();
-		openai::ImageDetail image_detail = vm["openai-image-detail"].as<openai::ImageDetail>();
+		openai::model model = vm["openai-model"].as<openai::model>();
+		openai::image_detail image_detail = vm["openai-image-detail"].as<openai::image_detail>();
 		chain |=
 			openai::analyze_data(api_key, model,
 				vm.count("openai-temperature") ? vm["openai-temperature"].as<float>() : 0,
@@ -407,8 +407,8 @@ int main(int argc, char* argv[])
 		const std::vector<std::string>& categories = vm["openai-classify"].as<std::vector<std::string>>();
 		std::set<std::string> categories_set(categories.begin(), categories.end());
 		std::string api_key = vm["openai-key"].as<std::string>();
-		openai::Model model = vm["openai-model"].as<openai::Model>();
-		openai::ImageDetail image_detail = vm["openai-image-detail"].as<openai::ImageDetail>();
+		openai::model model = vm["openai-model"].as<openai::model>();
+		openai::image_detail image_detail = vm["openai-image-detail"].as<openai::image_detail>();
 		chain |=
 			openai::classify(categories_set, api_key, model,
 				vm.count("openai-temperature") ? vm["openai-temperature"].as<float>() : 0,
@@ -419,8 +419,8 @@ int main(int argc, char* argv[])
 	{
 		std::string language = vm["openai-translate-to"].as<std::string>();
 		std::string api_key = vm["openai-key"].as<std::string>();
-		openai::Model model = vm["openai-model"].as<openai::Model>();
-		openai::ImageDetail image_detail = vm["openai-image-detail"].as<openai::ImageDetail>();
+		openai::model model = vm["openai-model"].as<openai::model>();
+		openai::image_detail image_detail = vm["openai-image-detail"].as<openai::image_detail>();
 		chain |=
 			openai::translate_to(language, api_key, model,
 				vm.count("openai-temperature") ? vm["openai-temperature"].as<float>() : 0,
@@ -448,11 +448,11 @@ int main(int argc, char* argv[])
 	{
 		try
 		{
-			EmbedPrefixType prefix_type = vm["local-ai-embed"].as<EmbedPrefixType>();
-			if (prefix_type == EmbedPrefixType::query)
+			embed_prefix_type prefix_type = vm["local-ai-embed"].as<embed_prefix_type>();
+			if (prefix_type == embed_prefix_type::query)
 			{
 				chain |= ai::local::query::embedder();
-			} else if (prefix_type == EmbedPrefixType::passage) {
+			} else if (prefix_type == embed_prefix_type::passage) {
           		chain |= ai::local::passage::embedder();
 	        } else {
            		chain |= ai::local::passage::embedder();
@@ -495,8 +495,8 @@ int main(int argc, char* argv[])
 	{
 		std::string what = vm["openai-find"].as<std::string>();
 		std::string api_key = vm["openai-key"].as<std::string>();
-		openai::Model model = vm["openai-model"].as<openai::Model>();
-		openai::ImageDetail image_detail = vm["openai-image-detail"].as<openai::ImageDetail>();
+		openai::model model = vm["openai-model"].as<openai::model>();
+		openai::image_detail image_detail = vm["openai-image-detail"].as<openai::image_detail>();
 		chain |=
 			openai::find(what, api_key, model,
 				vm.count("openai-temperature") ? vm["openai-temperature"].as<float>() : 0,
@@ -506,8 +506,8 @@ int main(int argc, char* argv[])
 	if (vm.count("openai-text-to-speech"))
 	{
 		std::string api_key = vm["openai-key"].as<std::string>();
-		openai::text_to_speech::Model model = vm["openai-tts-model"].as<openai::text_to_speech::Model>();
-		openai::text_to_speech::Voice voice = vm["openai-voice"].as<openai::text_to_speech::Voice>();
+		openai::text_to_speech::model model = vm["openai-tts-model"].as<openai::text_to_speech::model>();
+		openai::text_to_speech::voice voice = vm["openai-voice"].as<openai::text_to_speech::voice>();
 		chain |= openai::text_to_speech(api_key, model, voice);
 	}
 

--- a/src/docwire.cpp
+++ b/src/docwire.cpp
@@ -417,12 +417,12 @@ int main(int argc, char* argv[])
 
 	if (vm.count("openai-translate-to"))
 	{
-		std::string language = vm["openai-translate-to"].as<std::string>();
+		std::string target_language = vm["openai-translate-to"].as<std::string>();
 		std::string api_key = vm["openai-key"].as<std::string>();
 		openai::model model = vm["openai-model"].as<openai::model>();
 		openai::image_detail image_detail = vm["openai-image-detail"].as<openai::image_detail>();
 		chain |=
-			openai::translate_to(language, api_key, model,
+			openai::translate_to(target_language, api_key, model,
 				vm.count("openai-temperature") ? vm["openai-temperature"].as<float>() : 0,
 				image_detail);
 	}

--- a/src/extract_entities.cpp
+++ b/src/extract_entities.cpp
@@ -19,7 +19,7 @@ namespace docwire
 namespace openai
 {
 
-extract_entities::extract_entities(const std::string& api_key, Model model, float temperature, ImageDetail image_detail)
+extract_entities::extract_entities(const std::string& api_key, model model, float temperature, image_detail image_detail)
 	: chat("Your task is to find all dates, timespans, addresses, companies and person names inside every message. Show it as formatted list.", api_key, model, temperature, image_detail)
 {
 	log_scope(model, temperature, image_detail);

--- a/src/extract_entities.h
+++ b/src/extract_entities.h
@@ -22,7 +22,7 @@ namespace openai
 class DOCWIRE_OPENAI_EXPORT extract_entities : public chat
 {
 public:
-	explicit extract_entities(const std::string& api_key, Model model = Model::gpt_5, float temperature = 0.0f, ImageDetail image_detail = ImageDetail::automatic);
+	explicit extract_entities(const std::string& api_key, model model = model::gpt_5, float temperature = 0.0f, image_detail image_detail = image_detail::automatic);
 };
 
 } // namespace openai

--- a/src/extract_keywords.cpp
+++ b/src/extract_keywords.cpp
@@ -19,7 +19,7 @@ namespace docwire
 namespace openai
 {
 
-extract_keywords::extract_keywords(unsigned int max_keywords, const std::string& api_key, Model model, float temperature, ImageDetail image_detail)
+extract_keywords::extract_keywords(unsigned int max_keywords, const std::string& api_key, model model, float temperature, image_detail image_detail)
 	: chat("Your task is to identify and extract " +
 			std::to_string(max_keywords) +
 			" most important keywords or key phrases from every message. The goal is to capture the most relevant and significant terms within the text.",

--- a/src/extract_keywords.h
+++ b/src/extract_keywords.h
@@ -22,7 +22,7 @@ namespace openai
 class DOCWIRE_OPENAI_EXPORT extract_keywords : public chat
 {
 public:
-	extract_keywords(unsigned int max_keywords, const std::string& api_key, Model model = Model::gpt_5, float temperature = 0.0f, ImageDetail image_detail = ImageDetail::automatic);
+	extract_keywords(unsigned int max_keywords, const std::string& api_key, model model = model::gpt_5, float temperature = 0.0f, image_detail image_detail = image_detail::automatic);
 };
 
 } // namespace openai

--- a/src/find.cpp
+++ b/src/find.cpp
@@ -19,7 +19,7 @@ namespace docwire
 namespace openai
 {
 
-find::find(const std::string& what, const std::string& api_key, Model model, float temperature, ImageDetail image_detail)
+find::find(const std::string& what, const std::string& api_key, model model, float temperature, image_detail image_detail)
 	: chat("Your task is to find all occurrences of \"" + what + "\" in the provided text or image.\n\n"
 	       "1. On the first line, write only the total count of occurrences found. If none are found, write 0.\n"
 	       "2. On each subsequent line, provide a brief, one-sentence description of where each occurrence is located. For example: 'A red car is parked near the building on the left.' or 'The word \"processing\" appears in the first paragraph.'\n\n"

--- a/src/find.h
+++ b/src/find.h
@@ -22,7 +22,7 @@ namespace openai
 class DOCWIRE_OPENAI_EXPORT find : public chat
 {
 public:
-	find(const std::string& what, const std::string& api_key, Model model = Model::gpt_5, float temperature = 0.0f, ImageDetail image_detail = ImageDetail::automatic);
+	find(const std::string& what, const std::string& api_key, model model = model::gpt_5, float temperature = 0.0f, image_detail image_detail = image_detail::automatic);
 };
 
 } // namespace openai

--- a/src/iwork_parser.cpp
+++ b/src/iwork_parser.cpp
@@ -313,7 +313,7 @@ struct pimpl_impl<iwork_parser> : pimpl_impl_base
 	class xml_reader
 	{
 		public:
-			enum XmlElementKind
+			enum xml_element_kind
 			{
 				opening_element,	//<something>
 				closing_element,	//</something>
@@ -324,7 +324,7 @@ struct pimpl_impl<iwork_parser> : pimpl_impl_base
 
 			struct xml_element
 			{
-				XmlElementKind m_kind;
+				xml_element_kind m_kind;
 				std::map<std::string, std::string> m_attributes;
 				std::string m_name;
 				std::string m_characters;
@@ -512,7 +512,7 @@ struct pimpl_impl<iwork_parser> : pimpl_impl_base
 
 	struct iwork_content
 	{
-		enum IWorkType
+		enum iwork_type
 		{
 			pages,
 			numbers,
@@ -831,7 +831,7 @@ struct pimpl_impl<iwork_parser> : pimpl_impl_base
 		bool m_inside_text_body;
 		int m_footnote_start;
 		int m_footnote_count;
-		IWorkType m_iwork_type;
+		iwork_type m_iwork_type;
 		xml_reader* m_xml_reader;
 		std::map<std::string, XmlElementHandler> m_handlers;
 
@@ -876,7 +876,7 @@ struct pimpl_impl<iwork_parser> : pimpl_impl_base
 			ClearTextualElements();
 		}
 
-		void setType(IWorkType iwork_type)
+		void setType(iwork_type iwork_type)
 		{
 			m_iwork_type = iwork_type;
 		}
@@ -2048,7 +2048,7 @@ struct pimpl_impl<iwork_parser> : pimpl_impl_base
 		}
 	}
 
-	iwork_content::IWorkType getIWorkType(xml_reader& xml_reader)
+	iwork_content::iwork_type getIWorkType(xml_reader& xml_reader)
 	{
 		log_scope();
 		xml_reader::xml_element current_element;
@@ -2085,7 +2085,7 @@ struct pimpl_impl<iwork_parser> : pimpl_impl_base
 		iwork_content iwork_content(xml_reader);
 
 		throw_if (!zipfile.loadDirectory());
-		iwork_content::IWorkType iwork_type = getIWorkType(xml_reader);
+		iwork_content::iwork_type iwork_type = getIWorkType(xml_reader);
 		throw_if (iwork_type == iwork_content::encrypted, errors::file_encrypted{});
 		iwork_content.setType(iwork_type);
 		text.clear();

--- a/src/language.h
+++ b/src/language.h
@@ -15,7 +15,7 @@
 namespace docwire
 {
 
-enum class Language
+enum class language
 {
 	afr, ///< Afrikaans
 	amh, ///< Amharic

--- a/src/ocr_parser.cpp
+++ b/src/ocr_parser.cpp
@@ -87,7 +87,7 @@ template<>
 struct pimpl_impl<ocr_parser> : with_pimpl_owner<ocr_parser>
 {
     pimpl_impl(ocr_parser& owner) : with_pimpl_owner{owner} {}
-    std::vector<Language> m_languages;
+    std::vector<language> m_languages;
     ocr_confidence_threshold m_ocr_confidence_threshold;
     ocr_timeout m_ocr_timeout;
     ocr_data_path m_ocr_data_path;
@@ -235,7 +235,7 @@ const std::vector<mime_type> supported_mime_types
 
 } // anonymous namespace
 
-ocr_parser::ocr_parser(const std::vector<Language>& languages,
+ocr_parser::ocr_parser(const std::vector<language>& languages,
                      ocr_confidence_threshold ocr_confidence_threshold_arg,
                      ocr_timeout ocr_timeout_arg,
                      ocr_data_path ocr_data_path_arg)
@@ -247,7 +247,7 @@ ocr_parser::ocr_parser(const std::vector<Language>& languages,
     impl().m_ocr_data_path = ocr_data_path_arg.v.empty() ? default_tessdata_path() : ocr_data_path_arg;
 }
 
-void ocr_parser::parse(const data_source& data, const std::vector<Language>& languages)
+void ocr_parser::parse(const data_source& data, const std::vector<language>& languages)
 {
     log_scope(data, languages);
 
@@ -262,7 +262,7 @@ void ocr_parser::parse(const data_source& data, const std::vector<Language>& lan
     }
 
     std::string langs = std::accumulate(languages.begin(), languages.end(), std::string{},
-      [](const std::string& acc, const Language& lang)
+      [](const std::string& acc, const language& lang)
       {
         return acc + (acc.empty() ? "" : "+") + boost::lexical_cast<std::string>(lang);
       });
@@ -414,7 +414,7 @@ continuation ocr_parser::operator()(message_ptr msg, const message_callbacks& em
         log_scope(data);
         scoped::stack_push<context> context_guard{impl().m_context_stack, context{emit_message}};
         emit_message(document::document{.metadata = []() { return attributes::metadata{}; }});
-        parse(data, impl().m_languages.size() > 0 ? impl().m_languages : std::vector({ Language::eng }));
+        parse(data, impl().m_languages.size() > 0 ? impl().m_languages : std::vector({ language::eng }));
         emit_message(document::close_document{});
         return continuation::proceed;
     };

--- a/src/ocr_parser.h
+++ b/src/ocr_parser.h
@@ -44,7 +44,7 @@ private:
 
 public:
 
-    ocr_parser(const std::vector<Language>& languages = {},
+    ocr_parser(const std::vector<language>& languages = {},
         ocr_confidence_threshold ocr_confidence_threshold_arg = {},
         ocr_timeout ocr_timeout_arg = {},
         ocr_data_path ocr_data_path_arg = {});
@@ -54,7 +54,7 @@ public:
     bool is_leaf() const override { return false; }
 
 private:
-    void parse(const data_source& data, const std::vector<Language>& languages);
+    void parse(const data_source& data, const std::vector<language>& languages);
 };
 
 } // namespace docwire

--- a/src/odf_ooxml_parser.cpp
+++ b/src/odf_ooxml_parser.cpp
@@ -106,7 +106,7 @@ struct pimpl_impl<odf_ooxml_parser<safety_level>> : with_pimpl_owner<odf_ooxml_p
 		return m_context_stack.top().emit_message(std::forward<T>(object));
 	}
 
-		static void onOOXMLAttribute(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+		static void onOOXMLAttribute(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
 									 const zip_reader* zipfile, std::string& text,
 									 bool& children_processed, std::string& level_suffix, bool first_on_level)
 		{
@@ -114,7 +114,7 @@ struct pimpl_impl<odf_ooxml_parser<safety_level>> : with_pimpl_owner<odf_ooxml_p
 			children_processed = true;
 		}
 
-    void onOOXMLRow(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+    void onOOXMLRow(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
                            zip_reader* zipfile, std::string& text,
                            bool& children_processed, std::string& level_suffix, bool first_on_level)
     {
@@ -138,7 +138,7 @@ struct pimpl_impl<odf_ooxml_parser<safety_level>> : with_pimpl_owner<odf_ooxml_p
       emit_message(document::close_table_row{});
     }
 
-	void onOOXMLSheetData(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+	void onOOXMLSheetData(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
                          zip_reader* zipfile, std::string& text,
                          bool& children_processed, std::string& level_suffix, bool first_on_level)
   {
@@ -150,7 +150,7 @@ struct pimpl_impl<odf_ooxml_parser<safety_level>> : with_pimpl_owner<odf_ooxml_p
     emit_message(document::close_table{});
   }
 
-	void onOOXMLCell(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+	void onOOXMLCell(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
 								zip_reader* zipfile, std::string& text,
 								bool& children_processed, std::string& level_suffix, bool first_on_level)
 		{
@@ -215,7 +215,7 @@ struct pimpl_impl<odf_ooxml_parser<safety_level>> : with_pimpl_owner<odf_ooxml_p
 			children_processed = true;
 		}
 
-		static void onOOXMLHeaderFooter(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+		static void onOOXMLHeaderFooter(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
 										const zip_reader* zipfile, std::string& text,
 										bool& children_processed, std::string& level_suffix, bool first_on_level)
 		{
@@ -225,7 +225,7 @@ struct pimpl_impl<odf_ooxml_parser<safety_level>> : with_pimpl_owner<odf_ooxml_p
 			children_processed = true;
 		}
 
-	void onOOXMLCommentReference(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+	void onOOXMLCommentReference(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
 											const zip_reader* zipfile, std::string& text,
 											bool& children_processed, std::string& level_suffix, bool first_on_level)
 		{
@@ -241,7 +241,7 @@ struct pimpl_impl<odf_ooxml_parser<safety_level>> : with_pimpl_owner<odf_ooxml_p
 				emit_message(make_error_ptr("Comment not found, skipping", comment_id));
 		}
 
-	void onOOXMLHyperlink(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+	void onOOXMLHyperlink(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
 								  zip_reader* zipfile, std::string& text,
 								  bool& children_processed, std::string& level_suffix, bool first_on_level)
 		{
@@ -260,7 +260,7 @@ struct pimpl_impl<odf_ooxml_parser<safety_level>> : with_pimpl_owner<odf_ooxml_p
 				emit_message(make_error_ptr("Relationship not found, skipping", rid));
 		}
 
-		static void onOOXMLInstrtext(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+		static void onOOXMLInstrtext(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
 									 const zip_reader* zipfile, std::string& text,
 									 bool& children_processed, std::string& level_suffix, bool first_on_level)
 		{
@@ -268,7 +268,7 @@ struct pimpl_impl<odf_ooxml_parser<safety_level>> : with_pimpl_owner<odf_ooxml_p
 			children_processed = true;
 		}
 
-		static void onOOXMLTableStyleId(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+		static void onOOXMLTableStyleId(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
 									 const zip_reader* zipfile, std::string& text,
 									 bool& children_processed, std::string& level_suffix, bool first_on_level)
 		{
@@ -278,7 +278,7 @@ struct pimpl_impl<odf_ooxml_parser<safety_level>> : with_pimpl_owner<odf_ooxml_p
 		}
 
   void
-  onOOXMLStyle(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+  onOOXMLStyle(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
                                zip_reader* zipfile, std::string& text,
                                bool& children_processed, std::string& level_suffix, bool first_on_level)
   {
@@ -289,7 +289,7 @@ struct pimpl_impl<odf_ooxml_parser<safety_level>> : with_pimpl_owner<odf_ooxml_p
     owner().activeEmittingSignals(true);
   }
 
-	void onOOXMLBreak(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+	void onOOXMLBreak(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
 								const zip_reader* zipfile, std::string& text,
 								bool& children_processed, std::string& level_suffix, bool first_on_level) const
 	{
@@ -308,7 +308,7 @@ struct pimpl_impl<odf_ooxml_parser<safety_level>> : with_pimpl_owner<odf_ooxml_p
 			errors::file_encrypted{});
 	}
 
-	void readOOXMLComments(zip_reader& zipfile, XmlParseMode mode)
+	void readOOXMLComments(zip_reader& zipfile, xml_parse_mode mode)
 	{
 		log_scope(mode);
 		std::string content;
@@ -347,7 +347,7 @@ struct pimpl_impl<odf_ooxml_parser<safety_level>> : with_pimpl_owner<odf_ooxml_p
 		}
 	}
 
-	void readOOXMLRelationships(zip_reader& zipfile, XmlParseMode mode)
+	void readOOXMLRelationships(zip_reader& zipfile, xml_parse_mode mode)
 	{
 		log_scope(mode);
 		std::string content;
@@ -385,7 +385,7 @@ struct pimpl_impl<odf_ooxml_parser<safety_level>> : with_pimpl_owner<odf_ooxml_p
 		}
 	}
 
-	void readStyles(zip_reader& zipfile, XmlParseMode mode, const message_callbacks& emit_message)
+	void readStyles(zip_reader& zipfile, xml_parse_mode mode, const message_callbacks& emit_message)
 	{
 		log_scope(mode);
 		std::string content;
@@ -413,47 +413,47 @@ struct pimpl_impl<odf_ooxml_parser<safety_level>> : with_pimpl_owner<odf_ooxml_p
 template <safety_policy safety_level>
 odf_ooxml_parser<safety_level>::odf_ooxml_parser()
 {
-	registerODFOOXMLCommandHandler("attrName", [impl=impl()](xml::node_ref<safety_level>& xml_node, XmlParseMode mode, zip_reader* zipfile, std::string& text, bool& children_processed, std::string& level_suffix, bool first_on_level)
+	registerODFOOXMLCommandHandler("attrName", [impl=impl()](xml::node_ref<safety_level>& xml_node, xml_parse_mode mode, zip_reader* zipfile, std::string& text, bool& children_processed, std::string& level_suffix, bool first_on_level)
 	{
 		impl.onOOXMLAttribute(xml_node, mode, zipfile, text, children_processed, level_suffix, first_on_level);
 	});
-	registerODFOOXMLCommandHandler("c", [&impl=impl()](xml::node_ref<safety_level>& xml_node, XmlParseMode mode, zip_reader* zipfile, std::string& text, bool& children_processed, std::string& level_suffix, bool first_on_level)
+	registerODFOOXMLCommandHandler("c", [&impl=impl()](xml::node_ref<safety_level>& xml_node, xml_parse_mode mode, zip_reader* zipfile, std::string& text, bool& children_processed, std::string& level_suffix, bool first_on_level)
 	{
 		impl.onOOXMLCell(xml_node, mode, zipfile, text, children_processed, level_suffix, first_on_level);
 	});
-    registerODFOOXMLCommandHandler("row", [&impl=impl()](xml::node_ref<safety_level>& xml_node, XmlParseMode mode, zip_reader* zipfile, std::string& text, bool& children_processed, std::string& level_suffix, bool first_on_level)
+    registerODFOOXMLCommandHandler("row", [&impl=impl()](xml::node_ref<safety_level>& xml_node, xml_parse_mode mode, zip_reader* zipfile, std::string& text, bool& children_processed, std::string& level_suffix, bool first_on_level)
 	{
 		impl.onOOXMLRow(xml_node, mode, zipfile, text, children_processed, level_suffix, first_on_level);
 	});
-    registerODFOOXMLCommandHandler("sheetData", [&impl=impl()](xml::node_ref<safety_level>& xml_node, XmlParseMode mode, zip_reader* zipfile, std::string& text, bool& children_processed, std::string& level_suffix, bool first_on_level)
+    registerODFOOXMLCommandHandler("sheetData", [&impl=impl()](xml::node_ref<safety_level>& xml_node, xml_parse_mode mode, zip_reader* zipfile, std::string& text, bool& children_processed, std::string& level_suffix, bool first_on_level)
 	{
 		impl.onOOXMLSheetData(xml_node, mode, zipfile, text, children_processed, level_suffix, first_on_level);
 	});
-	registerODFOOXMLCommandHandler("headerFooter", [&impl=impl()](xml::node_ref<safety_level>& xml_node, XmlParseMode mode, zip_reader* zipfile, std::string& text, bool& children_processed, std::string& level_suffix, bool first_on_level)
+	registerODFOOXMLCommandHandler("headerFooter", [&impl=impl()](xml::node_ref<safety_level>& xml_node, xml_parse_mode mode, zip_reader* zipfile, std::string& text, bool& children_processed, std::string& level_suffix, bool first_on_level)
 	{
 		impl.onOOXMLHeaderFooter(xml_node, mode, zipfile, text, children_processed, level_suffix, first_on_level);
 	});
-	registerODFOOXMLCommandHandler("commentReference", [&impl=impl()](xml::node_ref<safety_level>& xml_node, XmlParseMode mode, zip_reader* zipfile, std::string& text, bool& children_processed, std::string& level_suffix, bool first_on_level)
+	registerODFOOXMLCommandHandler("commentReference", [&impl=impl()](xml::node_ref<safety_level>& xml_node, xml_parse_mode mode, zip_reader* zipfile, std::string& text, bool& children_processed, std::string& level_suffix, bool first_on_level)
 	{
 		impl.onOOXMLCommentReference(xml_node, mode, zipfile, text, children_processed, level_suffix, first_on_level);
 	});
-	registerODFOOXMLCommandHandler("hyperlink", [&impl=impl()](xml::node_ref<safety_level>& xml_node, XmlParseMode mode, zip_reader* zipfile, std::string& text, bool& children_processed, std::string& level_suffix, bool first_on_level)
+	registerODFOOXMLCommandHandler("hyperlink", [&impl=impl()](xml::node_ref<safety_level>& xml_node, xml_parse_mode mode, zip_reader* zipfile, std::string& text, bool& children_processed, std::string& level_suffix, bool first_on_level)
 	{
 		impl.onOOXMLHyperlink(xml_node, mode, zipfile, text, children_processed, level_suffix, first_on_level);
 	});
-	registerODFOOXMLCommandHandler("br", [&impl=impl()](xml::node_ref<safety_level>& xml_node, XmlParseMode mode, const zip_reader* zipfile, std::string& text, bool& children_processed, std::string& level_suffix, bool first_on_level)
+	registerODFOOXMLCommandHandler("br", [&impl=impl()](xml::node_ref<safety_level>& xml_node, xml_parse_mode mode, const zip_reader* zipfile, std::string& text, bool& children_processed, std::string& level_suffix, bool first_on_level)
 	{
 		impl.onOOXMLBreak(xml_node, mode, zipfile, text, children_processed, level_suffix, first_on_level);
     });
-	registerODFOOXMLCommandHandler("document-styles", [&impl=impl()](xml::node_ref<safety_level>& xml_node, XmlParseMode mode, zip_reader* zipfile, std::string& text, bool& children_processed, std::string& level_suffix, bool first_on_level)
+	registerODFOOXMLCommandHandler("document-styles", [&impl=impl()](xml::node_ref<safety_level>& xml_node, xml_parse_mode mode, zip_reader* zipfile, std::string& text, bool& children_processed, std::string& level_suffix, bool first_on_level)
 	{
 		impl.onOOXMLStyle(xml_node, mode, zipfile, text, children_processed, level_suffix, first_on_level);
     });
-	registerODFOOXMLCommandHandler("instrText", [impl=impl()](xml::node_ref<safety_level>& xml_node, XmlParseMode mode, zip_reader* zipfile, std::string& text, bool& children_processed, std::string& level_suffix, bool first_on_level)
+	registerODFOOXMLCommandHandler("instrText", [impl=impl()](xml::node_ref<safety_level>& xml_node, xml_parse_mode mode, zip_reader* zipfile, std::string& text, bool& children_processed, std::string& level_suffix, bool first_on_level)
 	{
 		impl.onOOXMLInstrtext(xml_node, mode, zipfile, text, children_processed, level_suffix, first_on_level);
 	});
-	registerODFOOXMLCommandHandler("tableStyleId", [impl=impl()](xml::node_ref<safety_level>& xml_node, XmlParseMode mode, zip_reader* zipfile, std::string& text, bool& children_processed, std::string& level_suffix, bool first_on_level)
+	registerODFOOXMLCommandHandler("tableStyleId", [impl=impl()](xml::node_ref<safety_level>& xml_node, xml_parse_mode mode, zip_reader* zipfile, std::string& text, bool& children_processed, std::string& level_suffix, bool first_on_level)
 	{
 		impl.onOOXMLTableStyleId(xml_node, mode, zipfile, text, children_processed, level_suffix, first_on_level);
 	});
@@ -484,7 +484,7 @@ void odf_ooxml_parser<safety_level>::setLastOOXMLColNum(int c)
 }
 
 template <safety_policy safety_level>
-void odf_ooxml_parser<safety_level>::parse(const data_source& data, XmlParseMode mode, const message_callbacks& emit_message)
+void odf_ooxml_parser<safety_level>::parse(const data_source& data, xml_parse_mode mode, const message_callbacks& emit_message)
 {
 	log_scope(data, mode);
 	zip_reader zipfile { data };
@@ -720,7 +720,7 @@ void odf_ooxml_parser<safety_level>::parse(const data_source& data, const messag
 	log_scope(data);
 	scoped_context_stack_push base_context_guard{*this, emit_message};
 	scoped::stack_push<context> context_guard{impl().m_context_stack, context{emit_message}};
-	parse(data, XmlParseMode::PARSE_XML, emit_message);
+	parse(data, xml_parse_mode::PARSE_XML, emit_message);
 }
 
 template <safety_policy safety_level>

--- a/src/odf_ooxml_parser.h
+++ b/src/odf_ooxml_parser.h
@@ -47,7 +47,7 @@ class DOCWIRE_ODF_OOXML_EXPORT odf_ooxml_parser : public common_xml_document_par
     void setLastOOXMLRowNum(int r);
     int lastOOXMLColNum();
     void setLastOOXMLColNum(int c);
-    void parse(const data_source& data, XmlParseMode mode, const message_callbacks& emit_message);
+    void parse(const data_source& data, xml_parse_mode mode, const message_callbacks& emit_message);
     attributes::metadata metaData(zip_reader& zipfile) const;
 
 	public:

--- a/src/odfxml_parser.cpp
+++ b/src/odfxml_parser.cpp
@@ -40,11 +40,11 @@ struct pimpl_impl<odfxml_parser<safety_level>> : with_pimpl_owner<odfxml_parser<
 {
 	using with_pimpl_owner<odfxml_parser<safety_level>>::owner;
 
-	void parse(const data_source& data, XmlParseMode mode, const message_callbacks& emit_message);
+	void parse(const data_source& data, xml_parse_mode mode, const message_callbacks& emit_message);
 	attributes::metadata extract_metadata(std::string_view xml_content) const;
 	pimpl_impl(odfxml_parser<safety_level>& owner) : with_pimpl_owner<odfxml_parser<safety_level>>{owner} {}
 
-		void onODFBody(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+		void onODFBody(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
 							  const zip_reader* zipfile, std::string& text,
 							  bool& children_processed, std::string& level_suffix, bool first_on_level)
 		{
@@ -60,7 +60,7 @@ struct pimpl_impl<odfxml_parser<safety_level>> : with_pimpl_owner<odfxml_parser<
 			owner().disableText(false);
 		}
 
-		void onODFObject(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+		void onODFObject(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
 								zip_reader* zipfile, std::string& text,
 								bool& children_processed, std::string& level_suffix, bool first_on_level)
 		{
@@ -70,7 +70,7 @@ struct pimpl_impl<odfxml_parser<safety_level>> : with_pimpl_owner<odfxml_parser<
 			owner().disableText(false);
 		}
 
-		void onODFBinaryData(xml::node_ref<safety_level>& xml_node, XmlParseMode mode,
+		void onODFBinaryData(xml::node_ref<safety_level>& xml_node, xml_parse_mode mode,
 									const zip_reader* zipfile, std::string& text,
 									bool& children_processed, std::string& level_suffix, bool first_on_level)
 		{
@@ -82,22 +82,22 @@ struct pimpl_impl<odfxml_parser<safety_level>> : with_pimpl_owner<odfxml_parser<
 template <safety_policy safety_level>
 odfxml_parser<safety_level>::odfxml_parser()
 {
-	registerODFOOXMLCommandHandler("body", [&impl=impl()](xml::node_ref<safety_level>& xml_node, XmlParseMode mode, zip_reader* zipfile, std::string& text, bool& children_processed, std::string& level_suffix, bool first_on_level)
+	registerODFOOXMLCommandHandler("body", [&impl=impl()](xml::node_ref<safety_level>& xml_node, xml_parse_mode mode, zip_reader* zipfile, std::string& text, bool& children_processed, std::string& level_suffix, bool first_on_level)
 	{
 		impl.onODFBody(xml_node, mode, zipfile, text, children_processed, level_suffix, first_on_level);
 	});
-	registerODFOOXMLCommandHandler("object", [&impl=impl()](xml::node_ref<safety_level>& xml_node, XmlParseMode mode, zip_reader* zipfile, std::string& text, bool& children_processed, std::string& level_suffix, bool first_on_level)
+	registerODFOOXMLCommandHandler("object", [&impl=impl()](xml::node_ref<safety_level>& xml_node, xml_parse_mode mode, zip_reader* zipfile, std::string& text, bool& children_processed, std::string& level_suffix, bool first_on_level)
 	{
 		impl.onODFObject(xml_node, mode, zipfile, text, children_processed, level_suffix, first_on_level);
 	});
-	registerODFOOXMLCommandHandler("binary-data", [&impl=impl()](xml::node_ref<safety_level>& xml_node, XmlParseMode mode, zip_reader* zipfile, std::string& text, bool& children_processed, std::string& level_suffix, bool first_on_level)
+	registerODFOOXMLCommandHandler("binary-data", [&impl=impl()](xml::node_ref<safety_level>& xml_node, xml_parse_mode mode, zip_reader* zipfile, std::string& text, bool& children_processed, std::string& level_suffix, bool first_on_level)
 	{
 		impl.onODFBinaryData(xml_node, mode, zipfile, text, children_processed, level_suffix, first_on_level);
 	});
 }
 
 template <safety_policy safety_level>
-void pimpl_impl<odfxml_parser<safety_level>>::parse(const data_source& data, XmlParseMode mode, const message_callbacks& emit_message)
+void pimpl_impl<odfxml_parser<safety_level>>::parse(const data_source& data, xml_parse_mode mode, const message_callbacks& emit_message)
 {
 	log_scope(mode);
 	std::string_view xml_content = data.string_view();
@@ -171,7 +171,7 @@ continuation odfxml_parser<safety_level>::operator()(message_ptr msg, const mess
 	log_entry();
 	try
 	{
-		impl().parse(data, XmlParseMode::PARSE_XML, emit_message);
+		impl().parse(data, xml_parse_mode::PARSE_XML, emit_message);
 	}
 	catch (const std::exception& e)
 	{

--- a/src/ppt_parser.cpp
+++ b/src/ppt_parser.cpp
@@ -35,7 +35,7 @@ namespace docwire
 
 using namespace wvWare;
 
-enum RecordType
+enum record_type
 {
 	RT_CSTRING = 0xFBA,
 	RT_DOCUMENT = 0x03E8,

--- a/src/rtf_parser.cpp
+++ b/src/rtf_parser.cpp
@@ -87,7 +87,7 @@ int parseCharCode(data_stream& data_stream)
 	return strtol(buf, (char **)NULL, 16);
 }
 
-enum RTFCommand
+enum rtf_command
 {
 	RTF_CODEPAGE,
 	RTF_FONT_CHARSET,
@@ -138,7 +138,7 @@ enum RTFCommand
 struct rtf_string_command
 {
 	const char* name;
-	RTFCommand cmd;
+	rtf_command cmd;
 };
 
 rtf_string_command rtf_commands[] =
@@ -205,7 +205,7 @@ struct rtf_parser_state
 	UString fldrslt_text;
 };
 
-RTFCommand commandNameToEnum(char* name)
+rtf_command commandNameToEnum(char* name)
 {
 	log_scope(name);
 	for (int i = 0; i < sizeof(rtf_commands) / sizeof(rtf_string_command); i++)
@@ -216,7 +216,7 @@ RTFCommand commandNameToEnum(char* name)
 	return RTF_UNKNOWN;
 }
 
-bool parseCommand(data_stream& data_stream, RTFCommand& cmd, long int& arg)
+bool parseCommand(data_stream& data_stream, rtf_command& cmd, long int& arg)
 {
 	log_scope();
 	char name[RTFNAMEMAXLEN + 1];
@@ -320,7 +320,7 @@ std::chrono::sys_seconds parse_dttm_time(int dttm)
 	return sys_days{ymd} + hours{hour} + minutes{min};
 }
 
-void execCommand(data_stream& data_stream, UString& text, int& skip, rtf_parser_state& state, RTFCommand cmd, long int arg,
+void execCommand(data_stream& data_stream, UString& text, int& skip, rtf_parser_state& state, rtf_command cmd, long int arg,
 	TextConverter*& converter, const std::function<void(std::exception_ptr)>& non_fatal_error_handler)
 {
 	log_scope(cmd, arg);
@@ -435,7 +435,7 @@ void execCommand(data_stream& data_stream, UString& text, int& skip, rtf_parser_
 				char ch = data_stream.getc();
 				if (ch == '\\')
 				{
-					RTFCommand tmp_cmd;
+					rtf_command tmp_cmd;
 					long int tmp_arg;
 					parseCommand(data_stream, tmp_cmd, tmp_arg);
 				}
@@ -596,7 +596,7 @@ void parse_rtf_content(const data_source& data, const message_callbacks& emit_me
 			{
 				case '\\':
 				{
-					RTFCommand cmd;
+					rtf_command cmd;
 					long int arg;
 					if (!parseCommand(*stream, cmd, arg))
 						break;

--- a/src/summarize.cpp
+++ b/src/summarize.cpp
@@ -19,7 +19,7 @@ namespace docwire
 namespace openai
 {
 
-summarize::summarize(const std::string& api_key, Model model, float temperature, ImageDetail image_detail)
+summarize::summarize(const std::string& api_key, model model, float temperature, image_detail image_detail)
 	: chat("Your task is to summarize every message", api_key, model, temperature, image_detail)
 {
 	log_scope(model, temperature, image_detail);

--- a/src/summarize.h
+++ b/src/summarize.h
@@ -22,7 +22,7 @@ namespace openai
 class DOCWIRE_OPENAI_EXPORT summarize : public chat
 {
 public:
-	explicit summarize(const std::string& api_key, Model model = Model::gpt_5, float temperature = 0.0f, ImageDetail image_detail = ImageDetail::automatic);
+	explicit summarize(const std::string& api_key, model model = model::gpt_5, float temperature = 0.0f, image_detail image_detail = image_detail::automatic);
 };
 
 } // namespace openai

--- a/src/text_to_speech.cpp
+++ b/src/text_to_speech.cpp
@@ -29,17 +29,17 @@ using namespace openai;
 template<>
 struct pimpl_impl<openai::text_to_speech> : pimpl_impl_base
 {
-	pimpl_impl(const std::string& api_key, text_to_speech::Model model, text_to_speech::Voice voice)
+	pimpl_impl(const std::string& api_key, text_to_speech::model model, text_to_speech::voice voice)
 		: m_api_key(api_key), m_model(model), m_voice(voice) {}
 	std::string m_api_key;
-	text_to_speech::Model m_model;
-	text_to_speech::Voice m_voice;
+	text_to_speech::model m_model;
+	text_to_speech::voice m_voice;
 };
 
 namespace openai
 {
 
-text_to_speech::text_to_speech(const std::string& api_key, Model model, Voice voice)
+text_to_speech::text_to_speech(const std::string& api_key, model model, voice voice)
 	: with_pimpl<text_to_speech>(api_key, model, voice)
 {
 	log_scope(model, voice);
@@ -48,32 +48,32 @@ text_to_speech::text_to_speech(const std::string& api_key, Model model, Voice vo
 namespace
 {
 
-std::string model_to_string(text_to_speech::Model model)
+std::string model_to_string(text_to_speech::model model)
 {
 	switch (model)
 	{
-		case text_to_speech::Model::gpt_4o_mini_tts: return "gpt-4o-mini-tts";
-		case text_to_speech::Model::tts_1: return "tts-1";
-		case text_to_speech::Model::tts_1_hd: return "tts-1-hd";
+		case text_to_speech::model::gpt_4o_mini_tts: return "gpt-4o-mini-tts";
+		case text_to_speech::model::tts_1: return "tts-1";
+		case text_to_speech::model::tts_1_hd: return "tts-1-hd";
 		default: return "?";
 	}
 }
 
-std::string voice_to_string(text_to_speech::Voice voice)
+std::string voice_to_string(text_to_speech::voice voice)
 {
 	switch (voice)
 	{
-		case text_to_speech::Voice::alloy: return "alloy";
-		case text_to_speech::Voice::echo: return "echo";
-		case text_to_speech::Voice::fable: return "fable";
-		case text_to_speech::Voice::onyx: return "onyx";
-		case text_to_speech::Voice::nova: return "nova";
-		case text_to_speech::Voice::shimmer: return "shimmer";
+		case text_to_speech::voice::alloy: return "alloy";
+		case text_to_speech::voice::echo: return "echo";
+		case text_to_speech::voice::fable: return "fable";
+		case text_to_speech::voice::onyx: return "onyx";
+		case text_to_speech::voice::nova: return "nova";
+		case text_to_speech::voice::shimmer: return "shimmer";
 		default: return "?";
 	}
 }
 
-std::string prepare_query(const std::string& input, text_to_speech::Model model, text_to_speech::Voice voice)
+std::string prepare_query(const std::string& input, text_to_speech::model model, text_to_speech::voice voice)
 {
 	log_scope(input, model, voice);
 	boost::json::object query

--- a/src/text_to_speech.h
+++ b/src/text_to_speech.h
@@ -25,17 +25,17 @@ namespace openai
 class DOCWIRE_OPENAI_EXPORT text_to_speech : public chain_element, public with_pimpl<text_to_speech>
 {
 public:
-	enum class Model
+	enum class model
 	{
 		gpt_4o_mini_tts, tts_1, tts_1_hd
 	};
 
-	enum class Voice
+	enum class voice
 	{
 		alloy, echo, fable, onyx, nova, shimmer
 	};
 
-	text_to_speech(const std::string& api_key, Model model = Model::gpt_4o_mini_tts, Voice voice = Voice::alloy);
+	text_to_speech(const std::string& api_key, model model = model::gpt_4o_mini_tts, voice voice = voice::alloy);
 
 	/**
 	* @brief Executes transform operation for given node data.

--- a/src/thread_safe_ole_storage.cpp
+++ b/src/thread_safe_ole_storage.cpp
@@ -51,14 +51,14 @@ struct pimpl_impl<thread_safe_ole_storage> : pimpl_impl_base
 	struct directory_entry
 	{
 		std::string m_name;
-		enum ObjectType
+		enum object_type
 		{
 			unknown_unallocated = 0x01,
 			storage = 0x01,
 			stream = 0x02,
 			root_storage = 0x05
 		};
-		ObjectType m_object_type;
+		object_type m_object_type;
 		uint8_t m_color_flag{0};
 		uint32_t m_left_sibling{0};
 		uint32_t m_right_sibling{0};
@@ -293,7 +293,7 @@ struct pimpl_impl<thread_safe_ole_storage> : pimpl_impl_base
 						m_is_valid_ole = false;
 						return;
 					}
-					directory->m_object_type = (directory_entry::ObjectType)object_type;
+					directory->m_object_type = (directory_entry::object_type)object_type;
 					uint8_t color_flag;
 					if (!m_data_stream->read(&color_flag, sizeof(uint8_t), 1))
 					{

--- a/src/transcribe.cpp
+++ b/src/transcribe.cpp
@@ -28,16 +28,16 @@ namespace docwire
 template<>
 struct pimpl_impl<openai::transcribe> : pimpl_impl_base
 {
-	pimpl_impl(const std::string& api_key, openai::transcribe::Model model)
+	pimpl_impl(const std::string& api_key, openai::transcribe::model model)
 		: m_api_key(api_key), m_model(model) {}
 	std::string m_api_key;
-	openai::transcribe::Model m_model;
+	openai::transcribe::model m_model;
 };
 
 namespace openai
 {
 
-transcribe::transcribe(const std::string& api_key, Model model)
+transcribe::transcribe(const std::string& api_key, model model)
 	: with_pimpl<transcribe>(api_key, model)
 {
 	log_scope(model);
@@ -46,13 +46,13 @@ transcribe::transcribe(const std::string& api_key, Model model)
 namespace
 {
 
-std::string model_to_string(transcribe::Model model)
+std::string model_to_string(transcribe::model model)
 {
 	switch (model)
 	{
-		case transcribe::Model::gpt_4o_transcribe: return "gpt-4o-transcribe";
-		case transcribe::Model::gpt_4o_mini_transcribe: return "gpt-4o-mini-transcribe";
-		case transcribe::Model::whisper_1: return "whisper-1";
+		case transcribe::model::gpt_4o_transcribe: return "gpt-4o-transcribe";
+		case transcribe::model::gpt_4o_mini_transcribe: return "gpt-4o-mini-transcribe";
+		case transcribe::model::whisper_1: return "whisper-1";
 		default: return "?";
 	}
 }

--- a/src/transcribe.h
+++ b/src/transcribe.h
@@ -24,12 +24,12 @@ namespace openai
 class DOCWIRE_OPENAI_EXPORT transcribe : public chain_element, public with_pimpl<transcribe>
 {
 public:
-	enum class Model
+	enum class model
 	{
 		gpt_4o_transcribe, gpt_4o_mini_transcribe, whisper_1
 	};
 
-	transcribe(const std::string& api_key, Model model = Model::gpt_4o_transcribe);
+	transcribe(const std::string& api_key, model model = model::gpt_4o_transcribe);
 
 	/**
 	* @brief Executes transform operation for given node data.

--- a/src/translate_to.cpp
+++ b/src/translate_to.cpp
@@ -19,7 +19,7 @@ namespace docwire
 namespace openai
 {
 
-translate_to::translate_to(const std::string& language, const std::string& api_key, Model model, float temperature, ImageDetail image_detail)
+translate_to::translate_to(const std::string& language, const std::string& api_key, model model, float temperature, image_detail image_detail)
 	: chat("Your task is to translate every message to " + language + " language.", api_key, model, temperature, image_detail)
 {
 	log_scope(language, model, temperature, image_detail);

--- a/src/translate_to.h
+++ b/src/translate_to.h
@@ -22,7 +22,7 @@ namespace openai
 class DOCWIRE_OPENAI_EXPORT translate_to : public chat
 {
 public:
-	translate_to(const std::string& language, const std::string& api_key, Model model = Model::gpt_5, float temperature = 0.0f, ImageDetail image_detail = ImageDetail::automatic);
+	translate_to(const std::string& language, const std::string& api_key, model model = model::gpt_5, float temperature = 0.0f, image_detail image_detail = image_detail::automatic);
 };
 
 } // namespace openai

--- a/src/xls_parser.cpp
+++ b/src/xls_parser.cpp
@@ -45,7 +45,7 @@ namespace
 	std::mutex xls_converter_mutex;
 	std::mutex parser_mutex;
 
-enum RecordType
+enum record_type
 {
 	XLS_BOF = 0x809,
 	XLS_CODEPAGE = 0x42,
@@ -69,7 +69,7 @@ enum RecordType
 	XLS_EOF = 0x0A
 };
 
-enum BiffVersion { BIFF2, BIFF3, BIFF4, BIFF5, BIFF8 };
+enum biff_version { BIFF2, BIFF3, BIFF4, BIFF5, BIFF8 };
 
 struct xf_record
 {
@@ -80,7 +80,7 @@ struct context
 {
 	const message_callbacks& emit_message;
 	std::string m_codepage = "cp1251";
-	BiffVersion m_biff_version;
+	biff_version m_biff_version;
 	std::vector<xf_record> m_xf_records;
 	double m_date_shift;
 	std::vector<std::string> m_shared_string_table;
@@ -746,7 +746,7 @@ struct pimpl_impl<xls_parser> : pimpl_impl_base
 			U16 rec_type, rec_len;
 			throw_if (!reader.readU16(rec_type) || !reader.readU16(rec_len), reader.getLastError());
 			log_entry(rec_type, rec_len);
-			enum BofRecordTypes
+			enum bof_record_types
 			{
 				BOF_BIFF_2 = 0x009,
 				BOF_BIFF_3 = 0x209,

--- a/src/xlsb_parser.cpp
+++ b/src/xlsb_parser.cpp
@@ -165,7 +165,7 @@ struct pimpl_impl<xlsb_parser> : pimpl_impl_base
 	class xlsb_reader
 	{
 		public:
-			enum RecordType
+			enum record_type
 			{
 				BRT_ROW_HDR = 0x0,
 				BRT_CELL_BLANK = 0x1,

--- a/src/xml_fixer.cpp
+++ b/src/xml_fixer.cpp
@@ -79,8 +79,8 @@ struct attr
 
 struct xml_tag
 {
-	enum Type { HEADER, OPENING, CLOSING, OPENING_AND_CLOSING };
-	Type type;
+	enum tag_type { HEADER, OPENING, CLOSING, OPENING_AND_CLOSING };
+	tag_type type;
 	xml_name name;
 	std::list<attr> attrs;
 
@@ -88,7 +88,7 @@ struct xml_tag
 	{
 	}
 
-	xml_tag(Type _type, const xml_name& _name)
+	xml_tag(tag_type _type, const xml_name& _name)
 		: type(_type), name(_name)
 	{
 	}

--- a/tests/document_parsing_tests.cpp
+++ b/tests/document_parsing_tests.cpp
@@ -95,8 +95,8 @@ std::vector<std::string> get_misc_test_files_list() {
 
 class document_parsing_tests : public ::testing::TestWithParam<std::string> {
 protected:
-    std::vector<Language> get_ocr_languages_from_filename(const std::string& file_name) const {
-        std::vector<Language> langs;
+    std::vector<language> get_ocr_languages_from_filename(const std::string& file_name) const {
+        std::vector<language> langs;
         if (file_name.length() > 4 &&
             (boost::algorithm::ends_with(file_name, ".png") ||
              boost::algorithm::ends_with(file_name, ".bmp") ||
@@ -109,14 +109,14 @@ protected:
             boost::split(fn_parts, file_name, boost::is_any_of("-."));
             for (const std::string& fn_part : fn_parts) {
                 std::string_view fn_part_view = fn_part;
-                std::optional<Language> lang = magic_enum::enum_cast<Language>(fn_part_view, magic_enum::case_insensitive);
+                std::optional<language> lang = magic_enum::enum_cast<language>(fn_part_view, magic_enum::case_insensitive);
                 if (lang) {
                     langs.push_back(*lang);
                 }
             }
         }
         if (langs.empty()) {
-            langs.push_back(Language::pol);
+            langs.push_back(language::pol);
         }
         return langs;
     }
@@ -129,7 +129,7 @@ protected:
         std::string expected_text{ std::istreambuf_iterator<char>{expected_ifs},
                                    std::istreambuf_iterator<char>{}};
 
-        std::vector<Language> ocr_langs = get_ocr_languages_from_filename(file_name);
+        std::vector<language> ocr_langs = get_ocr_languages_from_filename(file_name);
 
         std::ostringstream output_stream{};
         try {

--- a/tests/openai_find_image.cpp
+++ b/tests/openai_find_image.cpp
@@ -9,7 +9,7 @@ int main(int argc, char* argv[])
 
   try
   {
-    std::filesystem::path("scene_1.png") | content_type::detector{} | openai::find("tree", environment::get("OPENAI_API_KEY").value(), openai::Model::gpt_4o) | out_stream;
+    std::filesystem::path("scene_1.png") | content_type::detector{} | openai::find("tree", environment::get("OPENAI_API_KEY").value(), openai::model::gpt_4o) | out_stream;
     ensure(fuzzy_match::ratio(out_stream.str(), "2\n- A tree is located on the left side of the image near the people.\n- Another tree is in the background near the center of the image.\n")) > 80;
   }
   catch (const std::exception& e)

--- a/tests/openai_transcribe_summary.cpp
+++ b/tests/openai_transcribe_summary.cpp
@@ -8,7 +8,7 @@ int main(int argc, char* argv[])
 
   try
   {
-    std::filesystem::path("data_processing_definition.mp3") | openai::transcribe(environment::get("OPENAI_API_KEY").value()) | plain_text_exporter() | openai::summarize(environment::get("OPENAI_API_KEY").value(), openai::Model::gpt_4o) | out_stream;
+    std::filesystem::path("data_processing_definition.mp3") | openai::transcribe(environment::get("OPENAI_API_KEY").value()) | plain_text_exporter() | openai::summarize(environment::get("OPENAI_API_KEY").value(), openai::model::gpt_4o) | out_stream;
     ensure(fuzzy_match::ratio(out_stream.str(), "Data processing involves converting raw data into meaningful information by collecting, organizing, analyzing, and interpreting it. This process includes tasks like sorting, filtering, summarizing, and transforming data using computational and statistical methods. It is crucial in fields like business, science, and technology, as it helps organizations extract valuable insights from large datasets, make informed decisions, and enhance efficiency.\n")) > 80;
   }
   catch (const std::exception& e)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized public enum/type naming across OpenAI options, OCR languages, XML parsing modes, and several document-parser settings (including related command-line options), improving consistency between examples, CLI usage, and library calls.
  * Updated model/image-detail/language option handling and defaults to match the revised public interfaces.
* **Documentation**
  * Refreshed README OpenAI C++ examples to use the new lowercase model identifiers.
* **Tests**
  * Updated OpenAI and parsing test flows to use the revised type/enum names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->