### PR TITLE
Fix incorrect use of shallow wrapper std::initializer_list in exceptions

### DIFF
--- a/src/ensure.h
+++ b/src/ensure.h
@@ -16,6 +16,7 @@
 #include <cassert>
 #include "source_location.h"
 #include "throw_if.h"
+#include <vector>
 
 namespace docwire
 {
@@ -173,7 +174,7 @@ public:
                 return; // Match found, success.
             }
         }
-        DOCWIRE_THROW_IF_AT_LOCATION(true, m_location, m_value, expected_values);
+        DOCWIRE_THROW_IF_AT_LOCATION(true, m_location, m_value, std::vector<T>{expected_values});
     }
 private:
     /**

--- a/src/ensure.h
+++ b/src/ensure.h
@@ -174,7 +174,7 @@ public:
                 return; // Match found, success.
             }
         }
-        DOCWIRE_THROW_IF_AT_LOCATION(true, m_location, m_value, std::vector<T>{expected_values});
+        DOCWIRE_THROW_IF_AT_LOCATION(true, m_location, m_value, std::vector<T>(expected_values));
     }
 private:
     /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mismatch diagnostics when checking whether a value matches one of several expected options.
  * Error details now capture the expected values in a more consistent format when validation fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->