### PR TITLE
Adding fix to handle corner case scenarios for eml files where boundary is not present but content is present.

### DIFF
--- a/src/eml_parser.cpp
+++ b/src/eml_parser.cpp
@@ -238,8 +238,22 @@ struct pimpl_impl<eml_parser> : pimpl_impl_base
 			if (selected_part)
 				extractPlainText(*selected_part);
 		}
-		// TO DO: Handle the case, where boundary is declared but body does not
-		// contain a single boundary line.
+		else if (ct.media_type() == mime::media_type_t::MULTIPART && mime_entity.parts().empty() && !mime_entity.content().empty())
+		{
+			// Fix for Degenerate multipart: the header declared a multipart Content-Type,
+			// but the body never contained any boundary-delimited parts.
+			log_scope();
+			std::string plain_text = mime_entity.content();
+			plain_text.erase(std::remove(plain_text.begin(), plain_text.end(), '\r'), plain_text.end());
+			try
+			{
+				emit_message_back(data_source { plain_text, mime_type{"text/plain"}, confidence::high});
+			}
+			catch (std::exception&)
+			{
+				emit_message(errors::make_nested_ptr(std::current_exception(), make_error("Failed to process malformed multipart body with no parts")));
+			}
+		}
 		else
 		{
 			log_scope(mime_entity.parts().size());

--- a/src/eml_parser.cpp
+++ b/src/eml_parser.cpp
@@ -161,6 +161,24 @@ struct pimpl_impl<eml_parser> : pimpl_impl_base
 				}
 			}
 		}
+		else if (ct.media_type() == mime::media_type_t::MULTIPART && mime_entity.parts().empty())
+		{
+			std::string plain_text = mime_entity.content();
+			if (!plain_text.empty())
+			{
+				// Fix for Degenerate multipart: the header declared a multipart Content-Type,
+				// but the body never contained any boundary-delimited parts.
+				log_scope();
+				try
+				{
+					emit_message_back(data_source { plain_text, mime_type{"text/plain"}, confidence::high});
+				}
+				catch (std::exception&)
+				{
+					emit_message(errors::make_nested_ptr(std::current_exception(), make_error("Failed to process malformed multipart body with no parts")));
+				}
+			}
+		}
 		else if (ct.media_type() != mime::media_type_t::MULTIPART)
 		{
 			log_scope();
@@ -237,22 +255,6 @@ struct pimpl_impl<eml_parser> : pimpl_impl_base
 
 			if (selected_part)
 				extractPlainText(*selected_part);
-		}
-		else if (ct.media_type() == mime::media_type_t::MULTIPART && mime_entity.parts().empty() && !mime_entity.content().empty())
-		{
-			// Fix for Degenerate multipart: the header declared a multipart Content-Type,
-			// but the body never contained any boundary-delimited parts.
-			log_scope();
-			std::string plain_text = mime_entity.content();
-			plain_text.erase(std::remove(plain_text.begin(), plain_text.end(), '\r'), plain_text.end());
-			try
-			{
-				emit_message_back(data_source { plain_text, mime_type{"text/plain"}, confidence::high});
-			}
-			catch (std::exception&)
-			{
-				emit_message(errors::make_nested_ptr(std::current_exception(), make_error("Failed to process malformed multipart body with no parts")));
-			}
 		}
 		else
 		{

--- a/tests/document_parsing_tests.cpp
+++ b/tests/document_parsing_tests.cpp
@@ -78,7 +78,7 @@ std::vector<std::string> get_misc_test_files_list() {
         "header_folded_boundary.eml", "unnamed_attachment.eml",
         "multipart_related_html.eml", "html_attachment_alternative.eml",
         "endboundary_first.eml", "missing_inner_closing_boundary.eml",
-        "nested_multiparts_missing.eml", "valid_format.eml",
+        "nested_multiparts_missing.eml", "valid_format.eml", "no_multipart_start.eml",
         "html_with_doc_ext.doc", "html_with_xls_ext.xls", "rtf_with_doc_ext.doc",
         "comments_libreoffice_3.5.odt", "comments_libreoffice_3.5.doc",
         "comments_libreoffice_3.5.docx", "comments_libreoffice_3.5.rtf",

--- a/tests/no_multipart_start.eml
+++ b/tests/no_multipart_start.eml
@@ -1,0 +1,9 @@
+From: "Test Sender" <sender@example.com>
+To: <recipient@example.com>
+Subject: Multipart declared but no boundary lines present
+Date: Wed, 11 Jun 2025 10:00:00 +0000
+Message-ID: <no-multipart-start@example.com>
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="root"
+
+Just plain text, no boundaries at all here.

--- a/tests/no_multipart_start.eml.out
+++ b/tests/no_multipart_start.eml.out
@@ -1,0 +1,2 @@
+Just plain text, no boundaries at all here.
+


### PR DESCRIPTION
Also added the test file in tests folder for verirfication

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email parsing for malformed multipart messages that contain text but no detectable parts.
  * Plain-text content is now extracted correctly instead of being omitted.
  * Added clearer error reporting when malformed multipart content cannot be processed.

* **Tests**
  * Added coverage for multipart emails missing boundary delimiters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->