### PR TITLE
Fix intermittent SIGILL in CI: pin ggml/llama.cpp to a portable CPU baseline (#235)

### DIFF
--- a/ports/docwire/vcpkg.json
+++ b/ports/docwire/vcpkg.json
@@ -47,6 +47,14 @@
 			"llama-cpp"
 			]
 		},
+		"local-ai-llama-portable":
+		{
+			"description": "Enable GGUF-based LLM inference (llama.cpp)",
+			"dependencies": [
+			{ "name": "docwire", "features": ["local-ai-ct2"] },
+			{ "name": "llama-cpp", "features": ["portable-cpu"] }
+			]
+		},
     	"local-ai-model-granite":
 		{
 			"description": "Install IBM Granite 4.0 1B Q8_0 GGUF model",

--- a/ports/ggml/cmake-config.diff
+++ b/ports/ggml/cmake-config.diff
@@ -1,0 +1,20 @@
+diff --git a/cmake/ggml-config.cmake.in b/cmake/ggml-config.cmake.in
+index 91c9d5cd..0e0ef782 100644
+--- a/cmake/ggml-config.cmake.in
++++ b/cmake/ggml-config.cmake.in
+@@ -98,7 +98,6 @@ if (NOT GGML_SHARED_LIB)
+ endif()
+ 
+ set_and_check(GGML_INCLUDE_DIR "@PACKAGE_GGML_INCLUDE_INSTALL_DIR@")
+-set_and_check(GGML_LIB_DIR "@PACKAGE_GGML_LIB_INSTALL_DIR@")
+ #set_and_check(GGML_BIN_DIR "@PACKAGE_GGML_BIN_INSTALL_DIR@")
+ 
+ if(NOT TARGET ggml::ggml)
+@@ -112,6 +111,7 @@ if(NOT TARGET ggml::ggml)
+     add_library(ggml::ggml UNKNOWN IMPORTED)
+     set_target_properties(ggml::ggml
+         PROPERTIES
++            INTERFACE_INCLUDE_DIRECTORIES "${GGML_INCLUDE_DIR}"
+             IMPORTED_LOCATION "${GGML_LIBRARY}")
+ 
+     find_library(GGML_BASE_LIBRARY ggml-base

--- a/ports/ggml/fix-dequant_funcs.diff
+++ b/ports/ggml/fix-dequant_funcs.diff
@@ -1,0 +1,19 @@
+diff --git a/src/ggml-vulkan/vulkan-shaders/dequant_funcs.glsl b/src/ggml-vulkan/vulkan-shaders/dequant_funcs.glsl
+index 88d07d2d..a142d330 100644
+--- a/src/ggml-vulkan/vulkan-shaders/dequant_funcs.glsl
++++ b/src/ggml-vulkan/vulkan-shaders/dequant_funcs.glsl
+@@ -477,8 +477,12 @@ vec2 get_dm(uint ib, uint a_offset) {
+ 
+ #if defined(DATA_A_IQ1_M)
+ vec2 get_dm(uint ib, uint a_offset) {
+-    const uint16_t[4] scales = data_a[a_offset + ib].scales;
+-    const u16vec4 s = u16vec4(scales[0], scales[1], scales[2], scales[3]) >> 12;
++    const u16vec4 s = u16vec4(
++        data_a[a_offset + ib].scales[0],
++        data_a[a_offset + ib].scales[1],
++        data_a[a_offset + ib].scales[2],
++        data_a[a_offset + ib].scales[3]
++    ) >> 12;
+     const float d = float(unpackHalf2x16(s.x | (s.y << 4) | (s.z << 8) | (s.w << 12)).x);
+     return vec2(d, 0);
+ }

--- a/ports/ggml/fix-vk-32bit.diff
+++ b/ports/ggml/fix-vk-32bit.diff
@@ -1,0 +1,71 @@
+diff --git a/src/ggml-vulkan/ggml-vulkan.cpp b/src/ggml-vulkan/ggml-vulkan.cpp
+index 0a793100..a754ce42 100644
+--- a/src/ggml-vulkan/ggml-vulkan.cpp
++++ b/src/ggml-vulkan/ggml-vulkan.cpp
+@@ -2036,7 +2036,7 @@ void vk_memory_logger::log_allocation(vk_buffer_ref buf_ref, size_t size) {
+     allocations[buf->buffer] = size;
+     total_device += device ? size : 0;
+     total_host += device ? 0 : size;
+-    VK_LOG_MEMORY(buf->device->name << ": +" << format_size(size) << " " << type << " at " << buf->buffer << ". Total device: " << format_size(total_device) << ", total host: " << format_size(total_host));
++    VK_LOG_MEMORY(buf->device->name << ": +" << format_size(size) << " " << type << " at " << static_cast<VkBuffer>(buf->buffer) << ". Total device: " << format_size(total_device) << ", total host: " << format_size(total_host));
+ }
+ 
+ void vk_memory_logger::log_deallocation(vk_buffer_ref buf_ref) {
+@@ -2052,10 +2052,10 @@ void vk_memory_logger::log_deallocation(vk_buffer_ref buf_ref) {
+     total_device -= device ? it->second : 0;
+     total_host -= device ? 0 : it->second;
+     if (it != allocations.end()) {
+-        VK_LOG_MEMORY(buf->device->name << ": -" << format_size(it->second) << " " << type << " at " << buf->buffer << ". Total device: " << format_size(total_device) << ", total host: " << format_size(total_host));
++        VK_LOG_MEMORY(buf->device->name << ": -" << format_size(it->second) << " " << type << " at " << static_cast<VkBuffer>(buf->buffer) << ". Total device: " << format_size(total_device) << ", total host: " << format_size(total_host));
+         allocations.erase(it);
+     } else {
+-        VK_LOG_MEMORY("ERROR " << buf->device->name << ": Attempted to deallocate unknown " << type << " memory at " << buf->buffer);
++        VK_LOG_MEMORY("ERROR " << buf->device->name << ": Attempted to deallocate unknown " << type << " memory at " << static_cast<VkBuffer>(buf->buffer));
+     }
+ }
+ 
+@@ -6951,7 +6951,7 @@ static bool ggml_vk_buffer_write_2d_async(vk_context subctx, vk_buffer& dst, siz
+     }
+ 
+     ggml_vk_sync_buffers(nullptr, subctx);
+-    subctx->s->buffer->buf.copyBuffer((VkBuffer)staging_buffer->buffer, (VkBuffer)dst->buffer, slices);
++    subctx->s->buffer->buf.copyBuffer(staging_buffer->buffer, dst->buffer, slices);
+ 
+     if (width == spitch) {
+         deferred_memcpy((uint8_t *)staging_buffer->ptr, src, staging_size, &subctx->in_memcpys);
+@@ -7086,7 +7086,7 @@ static bool ggml_vk_buffer_read_async(vk_context subctx, vk_buffer& src, size_t
+ }
+ 
+ static void ggml_vk_buffer_read_2d(vk_buffer& src, size_t offset, void * dst, size_t spitch, size_t dpitch, size_t width, size_t height) {
+-    VK_LOG_DEBUG("ggml_vk_buffer_read_2d(" << src->buffer << ", " << offset << ", " << width << ", " << height << ")");
++    VK_LOG_DEBUG("ggml_vk_buffer_read_2d(" << static_cast<VkBuffer>(src->buffer) << ", " << offset << ", " << width << ", " << height << ")");
+ 
+     // If the device is not an UMA device the memory is host-accessible through rebar. While writing
+     // through PCIe is sufficient fast reading back data from PCIe is slower than going through
+@@ -7118,7 +7118,7 @@ static void ggml_vk_buffer_read_2d(vk_buffer& src, size_t offset, void * dst, si
+ }
+ 
+ static void ggml_vk_buffer_read(vk_buffer& src, size_t offset, void * dst, size_t size) {
+-    VK_LOG_DEBUG("ggml_vk_buffer_read(" << src->buffer << ", " << offset << ", " << size << ")");
++    VK_LOG_DEBUG("ggml_vk_buffer_read(" << static_cast<VkBuffer>(src->buffer) << ", " << offset << ", " << size << ")");
+     ggml_vk_buffer_read_2d(src, offset, dst, size, size, size, 1);
+ }
+ 
+@@ -7286,7 +7286,7 @@ static void ggml_vk_matmul(
+         uint32_t batch_stride_a, uint32_t batch_stride_b, uint32_t batch_stride_d,
+         uint32_t split_k, uint32_t batch, uint32_t ne02, uint32_t ne12, uint32_t broadcast2, uint32_t broadcast3,
+         uint32_t padded_n) {
+-        VK_LOG_DEBUG("ggml_vk_matmul(a: (" << a.buffer->buffer << ", " << a.offset << ", " << a.size << "), b: (" << b.buffer->buffer << ", " << b.offset << ", " << b.size << "), d: (" << d.buffer->buffer << ", " << d.offset << ", " << d.size << "), split_k: (" << (split_k_buffer.buffer != nullptr ? split_k_buffer.buffer->buffer : VK_NULL_HANDLE) << ", " << split_k_buffer.offset << ", " << split_k_buffer.size << "), m: " << m << ", n: " << n << ", k: " << k << ", stride_a: " << stride_a << ", stride_b: " << stride_b << ", stride_d: " << stride_d << ", batch_stride_a: " << batch_stride_a << ", batch_stride_b: " << batch_stride_b << ", batch_stride_d: " << batch_stride_d << ", split_k: " << split_k << ", batch: " << batch << ", ne02: " << ne02 << ", ne12: " << ne12 << ", broadcast2: " << broadcast2 << ", broadcast3: " << broadcast3 << ", padded_n: " << padded_n << ")");
++        VK_LOG_DEBUG("ggml_vk_matmul(a: (" << static_cast<VkBuffer>(a.buffer->buffer) << ", " << a.offset << ", " << a.size << "), b: (" << static_cast<VkBuffer>(b.buffer->buffer) << ", " << b.offset << ", " << b.size << "), d: (" << static_cast<VkBuffer>(d.buffer->buffer) << ", " << d.offset << ", " << d.size << "), split_k: (" << (split_k_buffer.buffer != nullptr ? static_cast<VkBuffer>(split_k_buffer.buffer->buffer) : VkBuffer{}) << ", " << split_k_buffer.offset << ", " << split_k_buffer.size << "), m: " << m << ", n: " << n << ", k: " << k << ", stride_a: " << stride_a << ", stride_b: " << stride_b << ", stride_d: " << stride_d << ", batch_stride_a: " << batch_stride_a << ", batch_stride_b: " << batch_stride_b << ", batch_stride_d: " << batch_stride_d << ", split_k: " << split_k << ", batch: " << batch << ", ne02: " << ne02 << ", ne12: " << ne12 << ", broadcast2: " << broadcast2 << ", broadcast3: " << broadcast3 << ", padded_n: " << padded_n << ")");
+     if (split_k == 1) {
+         ggml_pipeline_request_descriptor_sets(ctx, pipeline, CEIL_DIV(batch, ctx->device->properties.limits.maxComputeWorkGroupCount[2]));
+ 
+@@ -7366,7 +7366,7 @@ static void ggml_vk_matmul_id(
+         uint32_t batch_stride_a, uint32_t batch_stride_b, uint32_t batch_stride_d,
+         uint32_t n_as, uint32_t nei0, uint32_t nei1, uint32_t nbi1, uint32_t ne11,
+         uint32_t padded_n) {
+-    VK_LOG_DEBUG("ggml_vk_matmul_id(a: (" << a.buffer->buffer << ", " << a.offset << ", " << a.size << "), b: (" << b.buffer->buffer << ", " << b.offset << ", " << b.size << "), d: (" << d.buffer->buffer << ", " << d.offset << ", " << d.size << "), ids: (" << ids.buffer->buffer << ", " << ids.offset << ", " << ids.size << "), expert_count: (" << expert_count_buf.buffer->buffer << ", " << expert_count_buf.offset << ", " << expert_count_buf.size << "), " <<
++    VK_LOG_DEBUG("ggml_vk_matmul_id(a: (" << static_cast<VkBuffer>(a.buffer->buffer) << ", " << a.offset << ", " << a.size << "), b: (" << static_cast<VkBuffer>(b.buffer->buffer) << ", " << b.offset << ", " << b.size << "), d: (" << static_cast<VkBuffer>(d.buffer->buffer) << ", " << d.offset << ", " << d.size << "), ids: (" << static_cast<VkBuffer>(ids.buffer->buffer) << ", " << ids.offset << ", " << ids.size << "), expert_count: (" << static_cast<VkBuffer>(expert_count_buf.buffer->buffer) << ", " << expert_count_buf.offset << ", " << expert_count_buf.size << "), " <<
+         "m: " << m << ", n: " << n << ", k: " << k << ", stride_a: " << stride_a << ", stride_b: " << stride_b << ", stride_d: " << stride_d << ", " <<
+         "batch_stride_a: " << batch_stride_a << ", batch_stride_b: " << batch_stride_b << ", batch_stride_d: " << batch_stride_d << ", " <<
+         "n_as: " << n_as << ", nei0: " << nei0 << ", nei1: " << nei1 << ", nbi1: " << nbi1 << ", ne11: " << ne11 << ")");

--- a/ports/ggml/pkgconfig.diff
+++ b/ports/ggml/pkgconfig.diff
@@ -1,0 +1,216 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 672b37df..c6f16c7c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -352,7 +352,7 @@ if (GGML_STANDALONE)
+         @ONLY)
+ 
+     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ggml.pc
+-        DESTINATION share/pkgconfig)
++        DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+ endif()
+ 
+ #
+@@ -373,6 +373,7 @@ set(variable_set_statements
+ set(GGML_SHARED_LIB ${BUILD_SHARED_LIBS})
+ 
+ get_cmake_property(all_variables VARIABLES)
++list(FILTER all_variables EXCLUDE REGEX "^GGML_PKGCONFIG")
+ foreach(variable_name IN LISTS all_variables)
+     if(variable_name MATCHES "^GGML_")
+         string(REPLACE ";" "\\;"
+diff --git a/ggml.pc.in b/ggml.pc.in
+index 3e0291e0..a7627339 100644
+--- a/ggml.pc.in
++++ b/ggml.pc.in
+@@ -6,5 +6,7 @@ libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+ Name: ggml
+ Description: The GGML Tensor Library for Machine Learning
+ Version: @GGML_VERSION@
+-Cflags: -I${includedir}
+-Libs: -L${libdir} -lggml
++Cflags: -I${includedir} @GGML_PKGCONFIG_CFLAGS@
++Libs: -L${libdir} -lggml @GGML_PKGCONFIG_LIBS_BACKEND@ -lggml-base
++Libs.private: @GGML_PKGCONFIG_LIBS_PRIVATE@
++Requires.private: @GGML_PKGCONFIG_REQUIRES_PRIVATE@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 3e48860b..1ec27e83 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -185,6 +185,10 @@ endif()
+ 
+ # ggml
+ 
++set(GGML_PKGCONFIG_CFLAGS "")
++set(GGML_PKGCONFIG_LIBS_BACKEND "")
++set(GGML_PKGCONFIG_LIBS_PRIVATE "")
++
+ if (GGML_BACKEND_DL AND NOT BUILD_SHARED_LIBS)
+     message(FATAL_ERROR "GGML_BACKEND_DL requires BUILD_SHARED_LIBS")
+ endif()
+@@ -243,6 +247,7 @@ target_link_libraries(ggml PUBLIC ggml-base)
+ 
+ if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+     target_link_libraries(ggml PRIVATE dl)
++    string(APPEND GGML_PKGCONFIG_LIBS_PRIVATE " -ldl")
+ endif()
+ 
+ function(ggml_add_backend_library backend)
+@@ -296,12 +301,20 @@ function(ggml_add_backend backend)
+     string(TOUPPER "GGML_${backend}" backend_id)
+     if (${backend_id})
+         string(TOLOWER "ggml-${backend}" backend_target)
++        if (NOT GGML_BACKEND_DL)
++            # Mirrors ggml_add_backend_library but avoids cmake scoping
++            set(GGML_PKGCONFIG_LIBS_BACKEND "${GGML_PKGCONFIG_LIBS_BACKEND} -l${backend_target}")
++        endif()
+         add_subdirectory(${backend_target})
+         message(STATUS "Including ${backend} backend")
+         if (NOT GGML_BACKEND_DL)
+             string(TOUPPER "GGML_USE_${backend}" backend_use)
+             target_compile_definitions(ggml PUBLIC ${backend_use})
++            set(GGML_PKGCONFIG_CFLAGS "${GGML_PKGCONFIG_CFLAGS} -D${backend_use}" PARENT_SCOPE)
+         endif()
++        set(GGML_PKGCONFIG_LIBS_BACKEND "${GGML_PKGCONFIG_LIBS_BACKEND}" PARENT_SCOPE)
++        set(GGML_PKGCONFIG_LIBS_PRIVATE "${GGML_PKGCONFIG_LIBS_PRIVATE}" PARENT_SCOPE)
++        set(GGML_PKGCONFIG_REQUIRES_PRIVATE "${GGML_PKGCONFIG_REQUIRES_PRIVATE}" PARENT_SCOPE)
+     endif()
+ endfunction()
+ 
+@@ -474,10 +487,14 @@ if (DEFINED MATH_LIBRARY)
+     target_link_libraries(ggml-base PRIVATE ${MATH_LIBRARY})
+ elseif (NOT WIN32 AND NOT DEFINED ENV{ONEAPI_ROOT})
+     target_link_libraries(ggml-base PRIVATE m)
++    string(APPEND GGML_PKGCONFIG_LIBS_PRIVATE " -lm")
+ endif()
+ 
+ if (CMAKE_SYSTEM_NAME MATCHES "Android")
+     target_link_libraries(ggml-base PRIVATE dl)
++    if(NOT GGML_PKGCONFIG_LIBS_PRIVATE MATCHES " -ldl")
++        string(APPEND GGML_PKGCONFIG_LIBS_PRIVATE " -ldl")
++    endif()
+ endif()
+ 
+ if(CMAKE_SYSTEM_NAME MATCHES "visionOS")
+@@ -489,5 +506,11 @@ if (BUILD_SHARED_LIBS)
+         set_target_properties(${target} PROPERTIES POSITION_INDEPENDENT_CODE ON)
+         target_compile_definitions(${target} PRIVATE GGML_BUILD)
+         target_compile_definitions(${target} PUBLIC  GGML_SHARED)
++        string(APPEND GGML_PKGCONFIG_CFLAGS " -DGGML_SHARED -DGGML_BACKEND_SHARED")
+     endforeach()
+ endif()
++
++set(GGML_PKGCONFIG_CFLAGS "${GGML_PKGCONFIG_CFLAGS}" PARENT_SCOPE)
++set(GGML_PKGCONFIG_LIBS_BACKEND "${GGML_PKGCONFIG_LIBS_BACKEND}" PARENT_SCOPE)
++set(GGML_PKGCONFIG_LIBS_PRIVATE "${GGML_PKGCONFIG_LIBS_PRIVATE}" PARENT_SCOPE)
++set(GGML_PKGCONFIG_REQUIRES_PRIVATE "${GGML_PKGCONFIG_REQUIRES_PRIVATE}" PARENT_SCOPE)
+diff --git a/src/ggml-blas/CMakeLists.txt b/src/ggml-blas/CMakeLists.txt
+index c27dc174..ce1ab21d 100644
+--- a/src/ggml-blas/CMakeLists.txt
++++ b/src/ggml-blas/CMakeLists.txt
+@@ -93,6 +93,7 @@ if (BLAS_FOUND)
+     endif()
+ 
+     target_link_libraries     (ggml-blas PRIVATE ${BLAS_LIBRARIES})
++    set(GGML_PKGCONFIG_REQUIRES_PRIVATE "${GGML_PKGCONFIG_REQUIRES_PRIVATE} cblas" PARENT_SCOPE)
+     target_include_directories(ggml-blas SYSTEM PRIVATE ${BLAS_INCLUDE_DIRS})
+ else()
+     message(FATAL_ERROR "BLAS not found, please refer to "
+diff --git a/src/ggml-cpu/CMakeLists.txt b/src/ggml-cpu/CMakeLists.txt
+index 869c7b23..53a90f73 100644
+--- a/src/ggml-cpu/CMakeLists.txt
++++ b/src/ggml-cpu/CMakeLists.txt
+@@ -57,6 +57,9 @@ function(ggml_add_cpu_backend_variant_impl tag_name)
+     target_compile_features(${GGML_CPU_NAME} PRIVATE c_std_11 cxx_std_17)
+     target_include_directories(${GGML_CPU_NAME} PRIVATE . ggml-cpu)
+ 
++    set(libs_private "")
++    set(pkgconfig_cflags "")
++
+     if (APPLE AND GGML_ACCELERATE)
+         find_library(ACCELERATE_FRAMEWORK Accelerate)
+         if (ACCELERATE_FRAMEWORK)
+@@ -67,6 +70,7 @@ function(ggml_add_cpu_backend_variant_impl tag_name)
+             target_compile_definitions(${GGML_CPU_NAME} PRIVATE ACCELERATE_LAPACK_ILP64)
+ 
+             target_link_libraries(${GGML_CPU_NAME} PRIVATE ${ACCELERATE_FRAMEWORK})
++            string(APPEND libs_private " -framework Accelerate")
+         else()
+             message(WARNING "Accelerate framework not found")
+         endif()
+@@ -79,6 +83,18 @@ function(ggml_add_cpu_backend_variant_impl tag_name)
+             target_compile_definitions(${GGML_CPU_NAME} PRIVATE GGML_USE_OPENMP)
+ 
+             target_link_libraries(${GGML_CPU_NAME} PRIVATE OpenMP::OpenMP_C OpenMP::OpenMP_CXX)
++            set(items "")
++            foreach(lib IN LISTS OpenMP_CXX_LIB_NAMES OpenMP_C_LIB_NAMES)
++                list(REMOVE_ITEM items " -l${lib}")
++                list(APPEND items " -l${lib}")
++            endforeach()
++            string(APPEND libs_private ${items})
++            set(items "")
++            foreach(flag IN LISTS OpenMP_CXX_FLAGS OpenMP_C_FLAGS)
++                list(REMOVE_ITEM items " ${flag}")
++                list(APPEND items " ${flag}")
++            endforeach()
++            string(APPEND pkgconfig_cflags ${items})
+         else()
+             set(GGML_OPENMP_ENABLED "OFF" CACHE INTERNAL "")
+             message(WARNING "OpenMP not found")
+@@ -101,8 +117,12 @@ function(ggml_add_cpu_backend_variant_impl tag_name)
+         target_compile_definitions(${GGML_CPU_NAME} PRIVATE GGML_USE_CPU_HBM)
+ 
+         target_link_libraries(${GGML_CPU_NAME} PUBLIC memkind)
++        string(APPEND libs_private " -lmemkind")
+     endif()
+ 
++    set(GGML_PKGCONFIG_CFLAGS "${GGML_PKGCONFIG_CFLAGS}${pkgconfig_cflags}" PARENT_SCOPE)
++    set(GGML_PKGCONFIG_LIBS_PRIVATE "${GGML_PKGCONFIG_LIBS_PRIVATE}${libs_private}" PARENT_SCOPE)
++
+     if (GGML_SYSTEM_ARCH STREQUAL "ARM")
+         message(STATUS "ARM detected")
+         list(APPEND GGML_CPU_SOURCES
+diff --git a/src/ggml-metal/CMakeLists.txt b/src/ggml-metal/CMakeLists.txt
+index 42054d84..d780361e 100644
+--- a/src/ggml-metal/CMakeLists.txt
++++ b/src/ggml-metal/CMakeLists.txt
+@@ -19,6 +19,11 @@ target_link_libraries(ggml-metal PRIVATE
+                       ${METALKIT_FRAMEWORK}
+                       )
+ 
++set(GGML_PKGCONFIG_LIBS_PRIVATE
++    "${GGML_PKGCONFIG_LIBS_PRIVATE} -framework Foundation -framework Metal -framework MetalKit"
++    PARENT_SCOPE
++)
++
+ if (GGML_METAL_NDEBUG)
+     add_compile_definitions(GGML_METAL_NDEBUG)
+ endif()
+diff --git a/src/ggml-opencl/CMakeLists.txt b/src/ggml-opencl/CMakeLists.txt
+index ffde6a4f..9a7f9526 100644
+--- a/src/ggml-opencl/CMakeLists.txt
++++ b/src/ggml-opencl/CMakeLists.txt
+@@ -7,6 +7,7 @@ ggml_add_backend_library(${TARGET_NAME}
+                          ggml-opencl.cpp
+                          ../../include/ggml-opencl.h)
+ target_link_libraries(${TARGET_NAME} PRIVATE ${OpenCL_LIBRARIES})
++set(GGML_PKGCONFIG_REQUIRES_PRIVATE "${GGML_PKGCONFIG_REQUIRES_PRIVATE} OpenCL" PARENT_SCOPE)
+ target_include_directories(${TARGET_NAME} PRIVATE ${OpenCL_INCLUDE_DIRS})
+ 
+ if (GGML_OPENCL_PROFILING)
+diff --git a/src/ggml-vulkan/CMakeLists.txt b/src/ggml-vulkan/CMakeLists.txt
+index 715a263a..04c142c2 100644
+--- a/src/ggml-vulkan/CMakeLists.txt
++++ b/src/ggml-vulkan/CMakeLists.txt
+@@ -87,6 +87,11 @@ if (Vulkan_FOUND)
+     )
+ 
+     target_link_libraries(ggml-vulkan PRIVATE Vulkan::Vulkan)
++    if(ANDROID)
++        set(GGML_PKGCONFIG_LIBS_PRIVATE "${GGML_PKGCONFIG_LIBS_PRIVATE} -lvulkan" PARENT_SCOPE)
++    else()
++        set(GGML_PKGCONFIG_REQUIRES_PRIVATE "${GGML_PKGCONFIG_REQUIRES_PRIVATE} vulkan" PARENT_SCOPE)
++    endif()
+     target_include_directories(ggml-vulkan PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+ 
+     # Workaround to the "can't dereference invalidated vector iterator" bug in clang-cl debug build

--- a/ports/ggml/portfile.cmake
+++ b/ports/ggml/portfile.cmake
@@ -1,0 +1,105 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ggml-org/ggml
+    REF v${VERSION}
+    SHA512 9559545fea9606a5d9cd87fdd7ef1352ade4695305dfe27327abdc6cf598a8f159875f05992864cfd55405589b58ea3598181b64b3600bd5aa287a320c14d0b3
+    HEAD_REF master
+    PATCHES
+        cmake-config.diff
+        pkgconfig.diff
+        relax-link-options.diff
+        vulkan-shaders-gen.diff
+        fix-dequant_funcs.diff
+        fix-vk-32bit.diff
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        blas     			GGML_BLAS
+        cuda     			GGML_CUDA
+        metal    			GGML_METAL
+        opencl   			GGML_OPENCL
+        openmp   			GGML_OPENMP
+        vulkan   			GGML_VULKAN
+)
+
+if("blas" IN_LIST FEATURES)
+    vcpkg_find_acquire_program(PKGCONFIG)
+    list(APPEND FEATURE_OPTIONS
+        "-DCMAKE_REQUIRE_FIND_PACKAGE_BLAS=ON" # workaround message(ERROR ...)
+        "-DPKG_CONFIG_EXECUTABLE=${PKGCONFIG}"
+    )
+endif()
+
+if("cuda" IN_LIST FEATURES)
+    vcpkg_find_cuda(OUT_CUDA_TOOLKIT_ROOT cuda_toolkit_root)
+    list(APPEND FEATURE_OPTIONS
+        "-DCMAKE_CUDA_COMPILER=${NVCC}"
+        "-DCUDAToolkit_ROOT=${cuda_toolkit_root}"
+    )
+endif()
+
+if("opencl" IN_LIST FEATURES)
+    vcpkg_find_acquire_program(PYTHON3)
+    list(APPEND FEATURE_OPTIONS
+        "-DPython3_EXECUTABLE=${PYTHON3}"
+    )
+endif()
+
+if(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW AND VCPKG_TARGET_ARCHITECTURE STREQUAL "arm64")
+    message(STATUS "The CPU backend is not supported for arm64 with MSVC.")
+    list(APPEND FEATURE_OPTIONS
+        "-DGGML_CPU=OFF"
+    )
+    if(FEATURES STREQUAL "core")
+        message(WARNING "No backend enabled!")
+    endif()
+endif()
+
+if("vulkan" IN_LIST FEATURES AND VCPKG_CROSSCOMPILING)
+    list(APPEND FEATURE_OPTIONS
+        "-DVulkan_GLSLC_EXECUTABLE=${CURRENT_HOST_INSTALLED_DIR}/tools/shaderc/glslc${VCPKG_HOST_EXECUTABLE_SUFFIX}"
+        "-DVULKAN_SHADERS_GEN_EXECUTABLE=${CURRENT_HOST_INSTALLED_DIR}/tools/${PORT}/vulkan-shaders-gen${VCPKG_HOST_EXECUTABLE_SUFFIX}"
+    )
+endif()
+
+if("portable-cpu" IN_LIST FEATURES)
+    list(APPEND FEATURE_OPTIONS -DGGML_NATIVE=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_AVX512=OFF -DGGML_BMI2=OFF)
+endif()
+
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static"  GGML_STATIC)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DGGML_STATIC=${GGML_STATIC}
+        -DGGML_CCACHE=OFF
+        -DGGML_BUILD_NUMBER=1
+        -DGGML_BUILD_TESTS=OFF
+        -DGGML_BUILD_EXAMPLES=OFF
+        -DGGML_HIP=OFF
+        -DGGML_SYCL=OFF
+        ${FEATURE_OPTIONS}
+    MAYBE_UNUSED_VARIABLES
+        PKG_CONFIG_EXECUTABLE
+)
+
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup(PACKAGE_NAME ggml CONFIG_PATH "lib/cmake/ggml")
+vcpkg_fixup_pkgconfig()
+
+if(VCPKG_LIBRARY_LINKAGE STREQUAL "dynamic")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/ggml.h" "#ifdef GGML_SHARED" "#if 1")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/include/ggml-backend.h" "#ifdef GGML_BACKEND_SHARED" "#if 1")
+endif()
+
+if("vulkan" IN_LIST FEATURES AND NOT VCPKG_CROSSCOMPILING)
+    vcpkg_copy_tools(TOOL_NAMES vulkan-shaders-gen AUTO_CLEAN)
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/ports/ggml/relax-link-options.diff
+++ b/ports/ggml/relax-link-options.diff
@@ -1,0 +1,14 @@
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 1ec27e83..3cef2687 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -117,9 +117,7 @@ if (NOT MSVC)
+         if (UNIX AND NOT APPLE)
+             set(CMAKE_FIND_LIBRARY_SUFFIXES ".a;.so")
+         endif()
+-        add_link_options(-static)
+         if (MINGW)
+-            add_link_options(-static-libgcc -static-libstdc++)
+         endif()
+     endif()
+     if (GGML_GPROF)

--- a/ports/ggml/vcpkg.json
+++ b/ports/ggml/vcpkg.json
@@ -1,0 +1,71 @@
+{
+	"name": "ggml",
+	"version": "0.11.1",
+	"description": "Tensor library for machine learning",
+	"homepage": "https://github.com/ggml-org/ggml",
+	"license": "MIT",
+	"supports": "!uwp",
+	"dependencies": [
+		{
+			"name": "vcpkg-cmake",
+			"host": true
+		},
+		{
+			"name": "vcpkg-cmake-config",
+			"host": true
+		}
+	],
+	"features": {
+		"blas": {
+			"description": "Enable BLAS support",
+			"dependencies": [
+				"blas",
+				"cblas"
+			]
+		},
+		"cuda": {
+			"description": "Enable CUDA support",
+			"supports": "!(windows & staticcrt)",
+			"dependencies": [
+				"cuda"
+			]
+		},
+		"metal": {
+			"description": "Enable Metal support",
+			"supports": "osx"
+		},
+		"opencl": {
+			"description": "Enable OpenCL support",
+			"supports": "!arm32",
+			"dependencies": [
+				"opencl"
+			]
+		},
+		"openmp": {
+			"description": "Enable OpenMP support",
+			"supports": "!osx"
+		},
+		"vulkan": {
+			"description": "Enable Vulkan support",
+			"dependencies": [
+				{
+					"name": "ggml",
+					"host": true,
+					"default-features": false,
+					"features": [
+						"vulkan"
+					]
+				},
+				{
+					"name": "shaderc",
+					"host": true
+				},
+				"spirv-headers",
+				"vulkan"
+			]
+		},
+		"portable-cpu": {
+			"description": "Build without host-native CPU detection (GGML_NATIVE=OFF), targeting a conservative x86-64-v2-equivalent baseline for cross-runner cache portability (GitHub CI runners + VCPKG cache mechanism)."
+		}
+	}
+}

--- a/ports/ggml/vulkan-shaders-gen.diff
+++ b/ports/ggml/vulkan-shaders-gen.diff
@@ -1,0 +1,26 @@
+diff --git a/src/ggml-vulkan/CMakeLists.txt b/src/ggml-vulkan/CMakeLists.txt
+index 04c142c2..40a2791f 100644
+--- a/src/ggml-vulkan/CMakeLists.txt
++++ b/src/ggml-vulkan/CMakeLists.txt
+@@ -125,6 +125,12 @@ if (Vulkan_FOUND)
+         add_compile_definitions(GGML_VULKAN_RUN_TESTS)
+     endif()
+ 
++    if(DEFINED VULKAN_SHADERS_GEN_EXECUTABLE)
++        add_executable(vulkan-shaders-gen IMPORTED)
++        set_target_properties(vulkan-shaders-gen PROPERTIES IMPORTED_LOCATION "${VULKAN_SHADERS_GEN_EXECUTABLE}")
++    elseif(1)
++        add_subdirectory(vulkan-shaders)
++    elseif(0)
+     # Set up toolchain for host compilation whether cross-compiling or not
+     if (CMAKE_CROSSCOMPILING)
+         if (GGML_VULKAN_SHADERS_GEN_TOOLCHAIN)
+@@ -174,6 +180,8 @@ if (Vulkan_FOUND)
+     set (_ggml_vk_host_suffix $<IF:$<STREQUAL:${CMAKE_HOST_SYSTEM_NAME},Windows>,.exe,>)
+     set (_ggml_vk_genshaders_dir "${CMAKE_BINARY_DIR}/$<CONFIG>")
+     set (_ggml_vk_genshaders_cmd "${_ggml_vk_genshaders_dir}/vulkan-shaders-gen${_ggml_vk_host_suffix}")
++    endif()
++    set (_ggml_vk_genshaders_cmd "vulkan-shaders-gen")
+     set (_ggml_vk_header     "${CMAKE_CURRENT_BINARY_DIR}/ggml-vulkan-shaders.hpp")
+     set (_ggml_vk_input_dir  "${CMAKE_CURRENT_SOURCE_DIR}/vulkan-shaders")
+     set (_ggml_vk_output_dir "${CMAKE_CURRENT_BINARY_DIR}/vulkan-shaders.spv")

--- a/ports/llama-cpp/cmake-config.diff
+++ b/ports/llama-cpp/cmake-config.diff
@@ -1,0 +1,33 @@
+diff --git a/cmake/llama-config.cmake.in b/cmake/llama-config.cmake.in
+index 90cbec5..884938f 100644
+--- a/cmake/llama-config.cmake.in
++++ b/cmake/llama-config.cmake.in
+@@ -6,10 +6,10 @@ set(LLAMA_SHARED_LIB   @BUILD_SHARED_LIBS@)
+ @PACKAGE_INIT@
+ 
+ set_and_check(LLAMA_INCLUDE_DIR "@PACKAGE_LLAMA_INCLUDE_INSTALL_DIR@")
+-set_and_check(LLAMA_LIB_DIR     "@PACKAGE_LLAMA_LIB_INSTALL_DIR@")
+-set_and_check(LLAMA_BIN_DIR     "@PACKAGE_LLAMA_BIN_INSTALL_DIR@")
++#set_and_check(LLAMA_LIB_DIR     "@PACKAGE_LLAMA_LIB_INSTALL_DIR@")
++#set_and_check(LLAMA_BIN_DIR     "@PACKAGE_LLAMA_BIN_INSTALL_DIR@")
+ 
+-find_package(ggml REQUIRED HINTS ${LLAMA_LIB_DIR}/cmake)
++find_package(ggml REQUIRED CONFIG)
+ 
+ find_library(llama_LIBRARY llama
+     REQUIRED
+@@ -17,6 +17,7 @@ find_library(llama_LIBRARY llama
+     NO_CMAKE_FIND_ROOT_PATH
+ )
+ 
++if(NOT TARGET llama)
+ add_library(llama UNKNOWN IMPORTED)
+ set_target_properties(llama
+     PROPERTIES
+@@ -26,5 +27,6 @@ set_target_properties(llama
+         IMPORTED_LOCATION "${llama_LIBRARY}"
+         INTERFACE_COMPILE_FEATURES c_std_90
+         POSITION_INDEPENDENT_CODE ON)
++endif()
+ 
+ check_required_components(Llama)

--- a/ports/llama-cpp/pkgconfig.diff
+++ b/ports/llama-cpp/pkgconfig.diff
@@ -1,0 +1,12 @@
+diff --git a/cmake/llama.pc.in b/cmake/llama.pc.in
+index 6fb58b5..8a283e7 100644
+--- a/cmake/llama.pc.in
++++ b/cmake/llama.pc.in
+@@ -6,5 +6,6 @@ includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+ Name: llama
+ Description: Port of Facebook's LLaMA model in C/C++
+ Version: @LLAMA_INSTALL_VERSION@
+-Libs: -L${libdir} -lggml -lggml-base -lllama
++Requires: ggml
++Libs: -L${libdir} -lllama
+ Cflags: -I${includedir}

--- a/ports/llama-cpp/portfile.cmake
+++ b/ports/llama-cpp/portfile.cmake
@@ -1,0 +1,84 @@
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO ggml-org/llama.cpp
+    REF b${VERSION}
+    SHA512 ef5e21b61ca2961004fc57ad9d4a07191458df4f1749e71a9dc96d653676a6d68d43b7b8c74ebb235f6dffe5c064330cb1124887bc5c119876d7292543321945
+    HEAD_REF master
+    PATCHES
+        cmake-config.diff
+        pkgconfig.diff
+        unvendor.diff
+)
+file(REMOVE_RECURSE "${SOURCE_PATH}/ggml/include" "${SOURCE_PATH}/ggml/src")
+file(REMOVE_RECURSE
+    "${SOURCE_PATH}/vendor/cpp-httplib"
+    "${SOURCE_PATH}/vendor/miniaudio"
+    "${SOURCE_PATH}/vendor/nlohmann"
+    "${SOURCE_PATH}/vendor/stb")
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS options
+    FEATURES
+        download    LLAMA_CURL
+        server      LLAMA_BUILD_SERVER
+        tools       LLAMA_BUILD_TOOLS
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        ${options}
+        -DGGML_CCACHE=OFF
+        -DLLAMA_ALL_WARNINGS=OFF
+        -DLLAMA_BUILD_TESTS=OFF
+        -DLLAMA_BUILD_EXAMPLES=OFF
+        -DLLAMA_USE_SYSTEM_GGML=ON
+        -DVCPKG_LOCK_FIND_PACKAGE_Git=OFF
+)
+
+vcpkg_cmake_install()
+vcpkg_cmake_config_fixup(CONFIG_PATH "lib/cmake/llama")
+vcpkg_copy_pdbs()
+vcpkg_fixup_pkgconfig()
+
+file(INSTALL "${SOURCE_PATH}/gguf-py/gguf" DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}/gguf-py")
+file(RENAME "${CURRENT_PACKAGES_DIR}/bin/convert_hf_to_gguf.py" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/convert-hf-to-gguf.py")
+file(REMOVE "${CURRENT_PACKAGES_DIR}/debug/bin/convert_hf_to_gguf.py")
+
+if("tools" IN_LIST FEATURES)
+    set(tool_names
+        llama-batched-bench
+        llama-bench
+        llama-completion
+        llama-cvector-generator
+        llama-export-lora
+        llama-fit-params
+        llama-gguf-split
+        llama-imatrix
+        llama-mtmd-cli
+        llama-perplexity
+        llama-quantize
+        llama-results
+        llama-template-analysis
+        llama-tokenize
+        llama-tts
+    )
+    # https://github.com/ggml-org/llama.cpp/blob/master/tools/parser/CMakeLists.txt#L1
+    if(NOT VCPKG_TARGET_IS_WINDOWS OR VCPKG_LIBRARY_LINKAGE STREQUAL "static")
+        list(APPEND tool_names llama-debug-template-parser)
+    endif()
+    if("server" IN_LIST FEATURES)
+        list(APPEND tool_names llama-cli llama-server)
+    endif()
+    vcpkg_copy_tools(
+        TOOL_NAMES ${tool_names}
+        AUTO_CLEAN
+    )
+endif()
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+vcpkg_clean_executables_in_bin(FILE_NAMES none)
+
+set(gguf-py-license "${CURRENT_BUILDTREES_DIR}/${TARGET_TRIPLET}-rel/gguf-py LICENSE")
+file(COPY_FILE "${SOURCE_PATH}/gguf-py/LICENSE" "${gguf-py-license}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE" "${gguf-py-license}")

--- a/ports/llama-cpp/unvendor.diff
+++ b/ports/llama-cpp/unvendor.diff
@@ -1,0 +1,82 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 310a3dc..1f1495b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -197,8 +197,9 @@ add_subdirectory(src)
+ #
+
+ if (LLAMA_BUILD_COMMON)
++    find_package(httplib CONFIG REQUIRED)
++    add_library(cpp-httplib ALIAS httplib::httplib)
+     add_subdirectory(common)
+-    add_subdirectory(vendor/cpp-httplib)
+ endif()
+
+ if (LLAMA_BUILD_COMMON AND LLAMA_BUILD_TESTS AND NOT CMAKE_JS_VERSION)
+diff --git a/common/http.h b/common/http.h
+index d3daccd..be18264 100644
+--- a/common/http.h
++++ b/common/http.h
+@@ -1,6 +1,6 @@
+ #pragma once
+
+-#include <cpp-httplib/httplib.h>
++#include <httplib.h>
+
+ struct common_http_url {
+     std::string scheme;
+diff --git a/tools/mtmd/CMakeLists.txt b/tools/mtmd/CMakeLists.txt
+index 35d721d..18eabc4 100644
+--- a/tools/mtmd/CMakeLists.txt
++++ b/tools/mtmd/CMakeLists.txt
+@@ -53,7 +53,6 @@ target_link_libraries     (mtmd PUBLIC ggml llama)
+ target_link_libraries     (mtmd PRIVATE Threads::Threads)
+ target_include_directories(mtmd PUBLIC  .)
+ target_include_directories(mtmd PRIVATE ../..)
+-target_include_directories(mtmd PRIVATE ../../vendor)
+ target_compile_features   (mtmd PRIVATE cxx_std_17)
+
+ if (BUILD_SHARED_LIBS)
+diff --git a/tools/mtmd/mtmd-helper.cpp b/tools/mtmd/mtmd-helper.cpp
+index 4094074..d40ae74 100644
+--- a/tools/mtmd/mtmd-helper.cpp
++++ b/tools/mtmd/mtmd-helper.cpp
+@@ -27,10 +27,10 @@
+ #define MA_NO_ENGINE
+ #define MA_NO_GENERATION
+ #define MA_API static
+-#include "miniaudio/miniaudio.h"
++#include "miniaudio.h"
+
+ #define STB_IMAGE_IMPLEMENTATION
+-#include "stb/stb_image.h"
++#include "stb_image.h"
+
+ #ifdef MTMD_INTERNAL_HEADER
+ #error "mtmd-helper is a public library outside of mtmd. it must not include internal headers"
+diff --git a/tools/server/server-http.cpp b/tools/server/server-http.cpp
+index 6f24f83..40a5c85 100644
+--- a/tools/server/server-http.cpp
++++ b/tools/server/server-http.cpp
+@@ -2,7 +2,7 @@
+ #include "server-http.h"
+ #include "server-common.h"
+
+-#include <cpp-httplib/httplib.h>
++#include <httplib.h>
+
+ #include <functional>
+ #include <string>
+diff --git a/tools/server/server-models.cpp b/tools/server/server-models.cpp
+index 5a05ca2..3b7aef9 100644
+--- a/tools/server/server-models.cpp
++++ b/tools/server/server-models.cpp
+@@ -5,7 +5,7 @@
+ #include "preset.h"
+ #include "download.h"
+
+-#include <cpp-httplib/httplib.h> // TODO: remove this once we use HTTP client from download.h
++#include <httplib.h> // TODO: remove this once we use HTTP client from download.h
+ #include <sheredom/subprocess.h>
+
+ #include <functional>

--- a/ports/llama-cpp/vcpkg.json
+++ b/ports/llama-cpp/vcpkg.json
@@ -1,0 +1,53 @@
+{
+	"name": "llama-cpp",
+	"version": "9030",
+	"description": "LLM inference in C/C++",
+	"homepage": "https://github.com/ggml-org/llama.cpp",
+	"license": "MIT",
+	"dependencies": [
+		"cpp-httplib",
+		"ggml",
+		"nlohmann-json",
+		{
+			"name": "vcpkg-cmake",
+			"host": true
+		},
+		{
+			"name": "vcpkg-cmake-config",
+			"host": true
+		}
+	],
+	"features": {
+		"download": {
+			"description": "Support downloading a model from an URL",
+			"dependencies": [
+				{
+					"name": "curl",
+					"default-features": false
+				}
+			]
+		},
+		"server": {
+			"description": "Build llama-server and llama-cli"
+		},
+		"tools": {
+			"description": "Build tools",
+			"dependencies": [
+				"miniaudio",
+				"stb"
+			]
+		},
+		"portable-cpu": {
+			"description": "Build the underlying ggml CPU backend without host-native ISA detection, for CI-safe portable binaries. Forwards to ggml's portable-cpu feature.",
+			"dependencies": [
+				{
+					"name": "ggml",
+					"default-features": true,
+					"features": [
+						"portable-cpu"
+					]
+				}
+			]
+		}
+	}
+}


### PR DESCRIPTION
## Issue [https://github.com/docwire/docwire/issues/235]
 CI intermittently crashes with `SIGILL` (illegal instruction) when running tests that exercise the llama.cpp/GGUF local-AI integration(`local_ai_llama_integration`). 

## Fix
 
Added a `portable-cpu` vcpkg feature to the `ggml` overlay port that disables native CPU detection and pins the build to a conservative SIMD baseline, which is old enough that it's supported by effectively any CPU in cloud/CI circulation today,
regardless of which specific runner built or is consuming the cached binary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added package support for `ggml` and `llama.cpp`, including configurable BLAS, CUDA, Metal, OpenCL, OpenMP, Vulkan, and portable CPU builds.
  - Added optional portable CPU inference support for local AI applications.
  - Added support for building llama.cpp servers, command-line tools, model downloads, and GGUF workflows.

- **Bug Fixes**
  - Improved Vulkan compatibility on 32-bit platforms.
  - Corrected shader generation and quantization handling.

- **Build & Integration**
  - Improved CMake and pkg-config metadata for downstream projects and external dependencies.
  - Removed unnecessary static-linking requirements and improved package portability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->